### PR TITLE
Concat date with start & end times

### DIFF
--- a/data.py
+++ b/data.py
@@ -251,17 +251,17 @@ def parse_static_op_hours(hours_list, eatery_id):
   return new_operating_hours
 
 def format_time(start_time, end_time, start_date):
-  [start_hour, start_minute] = start_time.split(':')
-  [end_hour, end_minute] = end_time.split(':')
-  start_hour = '0' + start_hour if len(start_hour) < 2 else start_hour
-  end_hour = '0' + end_hour if len(end_hour) < 2 else end_hour
+  start_hour, start_minute = start_time.split(':')
+  end_hour, end_minute = end_time.split(':')
+  start_hour = start_hour.rjust(2, "0")
+  end_hour = end_hour.rjust(2, "0")
   end_date = start_date
-  if (int(end_hour) < int(start_hour) or end_hour == '12') and end_minute[-2:] == 'am':
-    [year, month, day] = start_date.split('-')
+  if (int(end_hour) < int(start_hour) or end_hour == '12') and end_minute.endswith('am'):
+    year, month, day = start_date.split('-')
     next_day = date(int(year), int(month), int(day)) + timedelta(days=1)
     end_date = next_day.isoformat()
-  new_start = start_date + ':' + start_hour + ':' + start_minute
-  new_end = end_date + ':' + end_hour + ':' + end_minute
+  new_start = "{}:{}:{}".format(start_date, start_hour, start_minute)
+  new_end = "{}:{}:{}".format(end_date, end_hour, end_minute)
   return [new_start, new_end]
 
 

--- a/data.py
+++ b/data.py
@@ -7,7 +7,7 @@ from constants import (
     UPDATE_DELAY,
     WEEKDAYS
 )
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from requests import get
 import schema
 from threading import Timer
@@ -82,26 +82,28 @@ def parse_operating_hours(eatery, eatery_id):
   new_operating_hours = []
   hours_list = eatery['operatingHours']
   for hours in hours_list:
+    new_date = hours.get('date', '')
     new_operating_hour = schema.OperatingHoursType(
-        date=hours.get('date', ''),
-        events=parse_events(hours['events'], eatery_id),
+        date=new_date,
+        events=parse_events(hours['events'], eatery_id, new_date),
         status=hours.get('status', '')
     )
     new_operating_hours.append(new_operating_hour)
   operating_hours[eatery_id] = new_operating_hours
   return new_operating_hours
 
-def parse_events(event_list, eatery_id):
+def parse_events(event_list, eatery_id, date):
   global events
   new_events = []
   for event in event_list:
+    [start, end] = format_time(event.get('start', ''), event.get('end', ''), date)
     stations = parse_food_stations(event['menu'], eatery_id)
     new_event = schema.EventType(
         cal_summary=event.get('calSummary', ''),
         description=event.get('descr', ''),
-        end_time=event.get('end', ''),
+        end_time=end,
         menu=stations,
-        start_time=event.get('start', ''),
+        start_time=start,
         station_count=len(stations)
     )
     new_events.append(new_event)
@@ -236,17 +238,31 @@ def parse_static_op_hours(hours_list, eatery_id):
   global today
   new_operating_hours = []
   for i in range(NUM_DAYS_STORED_IN_DB):
-    new_date = date(today.year, today.month, today.day + i)
+    new_date = today + timedelta(days=i)
     weekday = new_date.weekday()
     new_events = weekdays.get(weekday, [])
     new_operating_hour = schema.OperatingHoursType(
-        date=new_date,
-        events=parse_events(new_events, eatery_id),
+        date=new_date.isoformat(),
+        events=parse_events(new_events, eatery_id, new_date.isoformat()),
         status='EVENTS'
     )
     new_operating_hours.append(new_operating_hour)
   operating_hours[eatery_id] = new_operating_hours
   return new_operating_hours
+
+def format_time(start_time, end_time, start_date):
+  [start_hour, start_minute] = start_time.split(':')
+  [end_hour, end_minute] = end_time.split(':')
+  start_hour = '0' + start_hour if len(start_hour) < 2 else start_hour
+  end_hour = '0' + end_hour if len(end_hour) < 2 else end_hour
+  end_date = start_date
+  if (int(end_hour) < int(start_hour) or end_hour == '12') and end_minute[-2:] == 'am':
+    [year, month, day] = start_date.split('-')
+    next_day = date(int(year), int(month), int(day)) + timedelta(days=1)
+    end_date = next_day.isoformat()
+  new_start = start_date + ':' + start_hour + ':' + start_minute
+  new_end = end_date + ':' + end_hour + ':' + end_minute
+  return [new_start, new_end]
 
 
 start_update()

--- a/schema.py
+++ b/schema.py
@@ -58,9 +58,9 @@ class FoodStationType(ObjectType):
 class EventType(ObjectType):
   cal_summary = String(required=True)
   description = String(required=True)
-  end_time = String(required=True)
+  end_time = String(required=True)  # <isodate>:<time>
   menu = List(FoodStationType, required=True)
-  start_time = String(required=True)
+  start_time = String(required=True)  # <isodate>:<time>
   station_count = Int(required=True)
 
 class OperatingHoursType(ObjectType):


### PR DESCRIPTION
Concat date with start and end times to distinguish when operating hours extend into the next day.  Standardization of hours is as follows

isodate -> YYYY-MM-DD
time      ->  hh:mm<am or pm>

Now new with concat:
start_time -> isodate:time
end_time  -> isodate:time