### PR TITLE
Fix duplication of eateries

### DIFF
--- a/app.py
+++ b/app.py
@@ -9,13 +9,13 @@ app = Flask(__name__)
 schema = Schema(query=Query)
 
 app.add_url_rule(
-          '/',
-          view_func=GraphQLView.as_view(
-            'graphql',
-            schema=schema,
-            graphiql=True
-            )
-          )
+    '/',
+    view_func=GraphQLView.as_view(
+        'graphql',
+        schema=schema,
+        graphiql=True
+    )
+)
 
 if __name__ == '__main__':
   app.run(host='0.0.0.0', port=5000)

--- a/data.py
+++ b/data.py
@@ -18,6 +18,8 @@ events = {}
 items = {}
 menus = {}
 operating_hours = {}
+static_eateries = {}
+
 today = date.today()
 
 def start_update():
@@ -210,15 +212,16 @@ def parse_static_eateries(statics_json):
 
 def resolve_id(eatery):
   """Returns a new id (int) for an external eatery
-  If the eatery does not have a provided id, we need to make one for it.
-  Simply gets the maximum id currently in our eateries and makes new id +1
+  If the eatery does not have a provided id, we need to create one.
+  Since all provided eatery ID values are positive, we decrement starting at 0.
   """
   if 'id' in eatery:
     return eatery['id']
+  elif eatery['name'] in static_eateries:
+    return static_eateries['id']
 
-  global eateries
-  max_id = max(eateries)
-  return max_id + 1
+  static_eateries[eatery['name']] = -1 * len(static_eateries)
+  return -1 * len(static_eateries)
 
 def parse_eatery_type(eatery):
   try:


### PR DESCRIPTION
First commit fixes indentation issues in `app.py`.

Second commit fixes a bug where multiple `gunicorn` workers were causing static eateries to have duplicated data. The fix is to decrement IDs from 0, since all IDs are positive, and check whether the value exists in `static_eateries`.