### PR TITLE
Major refactoring of types

### DIFF
--- a/src/schema.py
+++ b/src/schema.py
@@ -1,107 +1,36 @@
 from datetime import datetime
 from dateutil import parser
 
-from graphene import Field, ObjectType, String, List, Int, Float, Boolean
-from graphene.types.datetime import Date, Time
+from graphene import Boolean, Field, Int, List, ObjectType, String
+from graphene.types.datetime import Date
 import pytz
 import requests
 
 from src.constants import *
+from src.types import (
+    AccountInfoType,
+    EateryType,
+    TransactionType,
+)
 
 class Data(object):
   eateries = {}
-  events = {}
-  menus = {}
 
   @staticmethod
-  def update_data(**kwargs):
-    Data.eateries = kwargs.get('eateries')
-    Data.events = kwargs.get('events')
-    Data.menus = kwargs.get('menus')
-
-class CoordinatesType(ObjectType):
-  latitude = Float(required=True)
-  longitude = Float(required=True)
-
-class CampusAreaType(ObjectType):
-  description = String(required=True)
-  description_short = String(required=True)
-
-class PaymentMethodsType(ObjectType):
-  brbs = Boolean(required=True)
-  cash = Boolean(required=True)
-  cornell_card = Boolean(required=True)
-  credit = Boolean(required=True)
-  mobile = Boolean(required=True)
-  swipes = Boolean(required=True)
-
-class DiningItemType(ObjectType):
-  category = String(required=True)
-  description = String(required=True)
-  healthy = Boolean(required=True)
-  item = String(required=True)
-  show_category = Boolean(required=True)
-
-class FoodItemType(ObjectType):
-  item = String(required=True)
-  healthy = Boolean(required=True)
-  sort_idx = Int(required=True)
-
-class FoodStationType(ObjectType):
-  category = String(required=True)
-  items = List(FoodItemType, required=True)
-  item_count = Int(required=True)
-  sort_idx = Int(required=True)
-
-class EventType(ObjectType):
-  cal_summary = String(required=True)
-  description = String(required=True)
-  end_time = String(required=True)  # <isodate>:<time>
-  menu = List(FoodStationType, required=True)
-  start_time = String(required=True)  # <isodate>:<time>
-  station_count = Int(required=True)
-
-class OperatingHoursType(ObjectType):
-  date = String(required=True)
-  events = List(EventType, required=True)
-  status = String(required=True)  # so far, we've only seen status = 'EVENT'
-
-class EateryType(ObjectType):
-  about = String(required=True)
-  about_short = String(required=True)
-  campus_area = Field(CampusAreaType, required=True)
-  coordinates = Field(CoordinatesType, required=True)
-  eatery_type = String(required=True)
-  id = Int(required=True)
-  image_url = String(required=True)
-  location = String(required=True)
-  name = String(required=True)
-  name_short = String(required=True)
-  operating_hours = List(OperatingHoursType, required=True)
-  payment_methods = Field(PaymentMethodsType, required=True)
-  phone = String(required=True)
-  slug = String(required=True)
-
-class TransactionType(ObjectType):
-  name = String(required=True)
-  timestamp = String(required=True)
-
-class AccountInfoType(ObjectType):
-  brbs = String(required=True)
-  cityBucks = String(required=True)
-  history = List(TransactionType, required=True)
-  laundry = String(required=True)
-  swipes = String(required=True)
+  def update_data(eateries):
+    Data.eateries = eateries
 
 class Query(ObjectType):
-  eateries = List(EateryType,
+  eateries = List(
+      EateryType,
       eatery_id=Int(name='id'),
       date=Date(),
       eatery_name=String(name='name'),
       campus_area=String(name='area'),
       is_open=Boolean()
   )
-  account_info = Field(AccountInfoType,
+  account_info = Field(
+      AccountInfoType,
       date=Date(),
       session_id=String(name='id')
   )
@@ -111,9 +40,6 @@ class Query(ObjectType):
       return [eatery for eatery in Data.eateries.values()]
     eatery = Data.eateries.get(eatery_id)
     return [eatery] if eatery is not None else []
-
-  def resolve_operating_hours(self, info, eatery_id=None):
-    print(list(Data.operating_hours.values())[0][0].date)
 
   def resolve_account_info(self, info, session_id=None):
     if session_id is None:
@@ -148,7 +74,7 @@ class Query(ObjectType):
 
     for acct in accounts:
       if acct['accountDisplayName'] == ACCOUNT_NAMES['citybucks']:
-        account_info['cityBucks'] = str(acct['balance'])
+        account_info['city_bucks'] = str(acct['balance'])
       elif acct['accountDisplayName'] == ACCOUNT_NAMES['laundry']:
         account_info['laundry'] = str("{0:.2f}".format(round(acct['balance'], 2)))
       elif acct['accountDisplayName'] == ACCOUNT_NAMES['brbs']:

--- a/src/types/__init__.py
+++ b/src/types/__init__.py
@@ -1,0 +1,5 @@
+from .account_info_type import AccountInfoType, TransactionType
+from .eatery_type import CampusAreaType, CoordinatesType, EateryType
+from .food_station_type import FoodItemType, FoodStationType
+from .operating_hours_type import EventType, OperatingHoursType
+from .payment_methods_type import PaymentMethodsType

--- a/src/types/account_info_type.py
+++ b/src/types/account_info_type.py
@@ -1,0 +1,12 @@
+from graphene import List, ObjectType, String
+
+class TransactionType(ObjectType):
+  name = String(required=True)
+  timestamp = String(required=True)
+
+class AccountInfoType(ObjectType):
+  brbs = String(required=True)
+  city_bucks = String(required=True)
+  history = List(TransactionType, required=True)
+  laundry = String(required=True)
+  swipes = String(required=True)

--- a/src/types/eatery_type.py
+++ b/src/types/eatery_type.py
@@ -1,0 +1,28 @@
+from graphene import Field, Float, Int, List, ObjectType, String
+
+from src.types.operating_hours_type import OperatingHoursType
+from src.types.payment_methods_type import PaymentMethodsType
+
+class CampusAreaType(ObjectType):
+  description = String(required=True)
+  description_short = String(required=True)
+
+class CoordinatesType(ObjectType):
+  latitude = Float(required=True)
+  longitude = Float(required=True)
+
+class EateryType(ObjectType):
+  about = String(required=True)
+  about_short = String(required=True)
+  campus_area = Field(CampusAreaType, required=True)
+  coordinates = Field(CoordinatesType, required=True)
+  eatery_type = String(required=True)
+  id = Int(required=True)
+  image_url = String(required=True)
+  location = String(required=True)
+  name = String(required=True)
+  name_short = String(required=True)
+  operating_hours = List(OperatingHoursType, required=True)
+  payment_methods = Field(PaymentMethodsType, required=True)
+  phone = String(required=True)
+  slug = String(required=True)

--- a/src/types/food_station_type.py
+++ b/src/types/food_station_type.py
@@ -1,0 +1,12 @@
+from graphene import Boolean, Int, List, ObjectType, String
+
+class FoodItemType(ObjectType):
+  item = String(required=True)
+  healthy = Boolean(required=True)
+  sort_idx = Int(required=True)
+
+class FoodStationType(ObjectType):
+  category = String(required=True)
+  items = List(FoodItemType, required=True)
+  item_count = Int(required=True)
+  sort_idx = Int(required=True)

--- a/src/types/operating_hours_type.py
+++ b/src/types/operating_hours_type.py
@@ -1,0 +1,16 @@
+from graphene import Int, List, ObjectType, String
+
+from src.types.food_station_type import FoodStationType
+
+class EventType(ObjectType):
+  cal_summary = String(required=True)
+  description = String(required=True)
+  end_time = String(required=True)  # <isodate>:<time>
+  menu = List(FoodStationType, required=True)
+  start_time = String(required=True)  # <isodate>:<time>
+  station_count = Int(required=True)
+
+class OperatingHoursType(ObjectType):
+  date = String(required=True)
+  events = List(EventType, required=True)
+  status = String(required=True)  # so far, we've only seen status = 'EVENT'

--- a/src/types/payment_methods_type.py
+++ b/src/types/payment_methods_type.py
@@ -1,0 +1,9 @@
+from graphene import Boolean, ObjectType
+
+class PaymentMethodsType(ObjectType):
+  brbs = Boolean(required=True)
+  cash = Boolean(required=True)
+  cornell_card = Boolean(required=True)
+  credit = Boolean(required=True)
+  mobile = Boolean(required=True)
+  swipes = Boolean(required=True)


### PR DESCRIPTION
The project is currently architected as follows:
```
src 
|-- schema.py
|-- data.py
```

`schema.py` was bloated with both resolvers and all types, so I changed the architecture to be the following:

```
src 
|-- schema.py
|-- data.py
|-- types/
     |-- __init__.py
     |-- account_info_type.py
     |-- eatery_type.py
     |-- food_station_type.py
     |-- operating_hours_type.py
     |-- payment_methods_type.py
```

I wanted to avoid having all the classes in one file, while avoiding having a file per each class (since each is only a few lines), so I tried to group by functionality.

I also verified that no functionality broke after this refactor.