### PR TITLE
Trim non-brb purchases

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -9,6 +9,7 @@ CORNELL_DINING_URL = 'https://now.dining.cornell.edu/api/1.0/dining/eateries.jso
 CORNELL_INSTITUTION_ID = '73116ae4-22ad-4c71-8ffd-11ba015407b1'
 GET_URL = 'https://services.get.cbord.com/GETServices/services/json'
 GIT_CONTENT_URL = 'https://raw.githubusercontent.com/cuappdev'
+IGNORE_LOCATIONS = ['BS-No Bill Workstation', 'Admin Workstation (B)']
 IMAGES_URL = GIT_CONTENT_URL + '/assets/master/eatery/eatery-images/'
 NUM_DAYS_STORED_IN_DB = 8
 PAY_METHODS = {

--- a/src/schema.py
+++ b/src/schema.py
@@ -10,6 +10,7 @@ from src.constants import (
     ACCOUNT_NAMES,
     CORNELL_INSTITUTION_ID,
     GET_URL,
+    IGNORE_LOCATIONS,
 )
 from src.types import (
     AccountInfoType,
@@ -135,10 +136,15 @@ class Query(ObjectType):
     account_info['history'] = []
 
     for t in transactions:
+      if ACCOUNT_NAMES['brbs'] not in t['accountName'] or t['locationName'] in IGNORE_LOCATIONS:
+        continue
       dt_utc = parser.parse(t['actualDate']).astimezone(pytz.timezone('UTC'))
       dt_est = dt_utc.astimezone(pytz.timezone('US/Eastern'))
       new_transaction = {
-          'name': t['locationName'],
+          'amount': t['amount'],
+          'name': t['locationName'][:t['locationName'].rfind(' ')],
+          # removes the register numbers at the end of the string by taking the substring up until
+          # the last space (right before the number)
           'timestamp': dt_est.strftime("%D at %I:%M %p")
       }
       account_info['history'].append(TransactionType(**new_transaction))

--- a/src/types/account_info_type.py
+++ b/src/types/account_info_type.py
@@ -1,6 +1,7 @@
 from graphene import List, ObjectType, String
 
 class TransactionType(ObjectType):
+  amount = String(required=True)
   name = String(required=True)
   timestamp = String(required=True)
 


### PR DESCRIPTION
Cleans up our history from GET to only show the brb related purchases (excludes laundry, deposits, other cornell internal things).  Also strips the register number from the location