### PR TITLE
Refactor: Documentation + File restructure

### DIFF
--- a/src/data.py
+++ b/src/data.py
@@ -4,37 +4,22 @@ from threading import Timer
 import requests
 
 from src.collegetown import collegetown_search
+from src.eatery import (
+    parse_eatery,
+    parse_collegetown_eateries,
+    parse_static_eateries
+)
 from src.constants import (
     CORNELL_DINING_URL,
     IMAGES_URL,
-    NUM_DAYS_STORED_IN_DB,
-    PAY_METHODS,
     STATIC_EATERIES_URL,
     STATIC_MENUS_URL,
-    TRILLIUM_ID,
-    UPDATE_DELAY,
-    WEEKDAYS,
+    UPDATE_DELAY
 )
 from src.schema import Data
-from src.types import (
-    CampusAreaType,
-    CampusEateryType,
-    CollegetownEateryType,
-    CollegetownEventType,
-    CollegetownHoursType,
-    CoordinatesType,
-    EventType,
-    FoodItemType,
-    FoodStationType,
-    OperatingHoursType,
-    PaymentMethodsType,
-)
 
 campus_eateries = {}
 collegetown_eateries = {}
-static_eateries = {}
-
-today = date.today()
 
 def start_update():
   """Starts the data retrieval process.
@@ -48,375 +33,33 @@ def start_update():
     # Get data for on-campus, Cornell-owned dining Options
     dining_query = requests.get(CORNELL_DINING_URL)
     data_json = dining_query.json()
-    parse_eatery(data_json)
+    parse_eatery(data_json, campus_eateries)
     merge_hours(campus_eateries)
     # Get data for on-campus, 3rd-party dining options
     static_json = requests.get(STATIC_EATERIES_URL).json()
-    parse_static_eateries(static_json)
+    parse_static_eateries(static_json, campus_eateries)
     Data.update_data(campus_eateries)
     # Get data for Collegetown eateries
     print('[{}] Updating collegetown'.format(datetime.now()))
     yelp_query = collegetown_search()
-    parse_collegetown_eateries(yelp_query)
+    parse_collegetown_eateries(yelp_query, collegetown_eateries)
     Data.update_collegetown_data(collegetown_eateries)
   except Exception as e:
     print('Data update failed:', e)
   finally:
     Timer(UPDATE_DELAY, start_update).start()
 
-def parse_eatery(data_json):
-  """Parses a Cornell Dining json dictionary.
-
-  Fills the campus_eateries dictionary with objects of type CampusEateryType.
-
-  Args:
-      data_json (dict): a valid dictionary from the Cornell Dining json
-  """
-  for eatery in data_json['data']['eateries']:
-    eatery_id = eatery.get('id', resolve_id(eatery))
-    dining_items = get_trillium_menu() if eatery_id == TRILLIUM_ID else parse_dining_items(eatery)
-    phone = eatery.get('contactPhone', 'N/A')
-    phone = phone if phone else 'N/A'  # handle None values
-
-    new_eatery = CampusEateryType(
-        about=eatery.get('about', ''),
-        campus_area=parse_campus_area(eatery),
-        coordinates=parse_coordinates(eatery),
-        eatery_type=parse_eatery_type(eatery),
-        id=eatery_id,
-        image_url=get_image_url(eatery.get('slug', '')),
-        location=eatery.get('location', ''),
-        name=eatery.get('name', ''),
-        name_short=eatery.get('nameshort', ''),
-        operating_hours=parse_operating_hours(eatery, dining_items),
-        payment_methods=parse_payment_methods(eatery['payMethods']),
-        phone=phone,
-        slug=eatery.get('slug', '')
-    )
-    campus_eateries[new_eatery.id] = new_eatery
-
-def get_image_url(slug):
-  """Generates a URL for an image.
-
-  Creates a string that represents a url pointing towards the eatery image.
-
-  Args:
-      slug (string): a slugged name of an eatery
-  """
-  return "{}{}.jpg".format(IMAGES_URL, slug)
-
-def parse_payment_methods(methods):
-  """Returns a PaymentMethodsType according to which payment methods are available at an eatery.
-  Args:
-      methods (json): a valid json segment for payments from Cornell Dining
-  """
-  payment_methods = PaymentMethodsType()
-  payment_methods.brbs = any(pay['descrshort'] == PAY_METHODS['brbs'] for pay in methods)
-  payment_methods.cash = any(pay['descrshort'] == PAY_METHODS['credit'] for pay in methods)
-  payment_methods.credit = any(pay['descrshort'] == PAY_METHODS['credit'] for pay in methods)
-  payment_methods.cornell_card = any(pay['descrshort'] == PAY_METHODS['c-card'] for pay in methods)
-  payment_methods.mobile = any(pay['descrshort'] == PAY_METHODS['mobile'] for pay in methods)
-  payment_methods.swipes = any(pay['descrshort'] == PAY_METHODS['swipes'] for pay in methods)
-  return payment_methods
-
-def parse_operating_hours(eatery, dining_items):
-  """Returns a list of OperatingHoursTypes for each dining event for an eatery.
-
-  Calls parse_events to populate the events field for OperatingHoursType.
-
-  Args:
-      eatery (dict): A valid json segment from Cornell Dining that contains eatery information
-      dining_items (list): A list that holds a dictionary for the items an eatery serves and a flag
-       for healthy options
-  """
-  new_operating_hours = []
-  hours_list = eatery['operatingHours']
-  for hours in hours_list:
-    new_date = hours.get('date', '')
-    hours_events = hours['events']
-    #merge the dining items from the json (for non-dining hall eateries) with the menu for an event
-    for event in hours_events:
-      if not event['menu'] and dining_items:
-        event['menu'] = dining_items
-
-    new_operating_hour = OperatingHoursType(
-        date=new_date,
-        events=parse_events(hours_events, new_date)
-    )
-    new_operating_hours.append(new_operating_hour)
-  return new_operating_hours
-
-def parse_events(event_list, event_date):
-  """Parses the events of an eatery.
-
-  Returns a list of EventType for each event of an eatery. Calls parse_food_stations to populate
-  the menu field for EventType.
-
-  Args:
-      event_list (list): The list of all events for an eatery
-      event_date (string): The date of all of the events of the eatery
-  """
-  new_events = []
-  for event in event_list:
-    start, end = format_time(event.get('start', ''), event.get('end', ''), event_date)
-    new_event = EventType(
-        cal_summary=event.get('calSummary', ''),
-        description=event.get('descr', ''),
-        end_time=end,
-        menu=parse_food_stations(event.get('menu', [])),
-        start_time=start
-    )
-    new_events.append(new_event)
-  return new_events
-
-def parse_food_stations(station_list):
-  """Parses the food stations available at an event
-
-  Returns a list containing FoodStationTypes for an eatery. Calls parse_food_items to populate
-  the items field for FoodStationType.
-
-  Args:
-      station_list (list): A list representing all of the stations in a dining hall
-  """
-  new_stations = []
-  if len(station_list) == 1 and not station_list[0]['items']:  # no menu actually provided
-    return new_stations
-  for station in station_list:
-    new_station = FoodStationType(
-        category=station.get('category', ''),
-        items=parse_food_items(station.get('items', []))
-    )
-    new_stations.append(new_station)
-  return new_stations
-
-def parse_food_items(item_list):
-  """Parses the food items available at a food station.
-
-  Returns a list containing FoodItemTypes for an eatery. This is the lowest level that
-  is parsed for a dining hall.
-
-  Args:
-      item_list (list): A list representing the individual food items for each station
-  """
-  new_food_items = []
-  for item in item_list:
-    new_food_items.append(
-        FoodItemType(
-            healthy=item.get('healthy', False),
-            item=item.get('item', '')
-        )
-    )
-  return new_food_items
-
-def parse_dining_items(eatery):
-  """Parses the dining items of an eatery.
-
-  Returns a list that holds a dictionary for the items an eatery serves and a flag for healthy
-  options. Exclusive to non-dining hall eateries.
-
-  Args:
-      eatery (dict): A valid json dictionary from Cornell Dining that contains eatery information
-  """
-  dining_items = {'items': []}
-  for item in eatery['diningItems']:
-    dining_items['items'].append({
-        'healthy': item.get('healthy', False),
-        'item': item.get('item', '')
-    })
-  return [dining_items]
-
-def parse_coordinates(eatery):
-  """Parses the coordinates of an eatery.
-
-  Returns a new CoordinateType that holds the geographic coordinates of an eatery.
-
-  Args:
-      eatery (dict): A valid json dictionary from Cornell Dining that contains eatery information
-  """
-  latitude, longitude = 0.0, 0.0
-  if 'coordinates' in eatery:
-    latitude = eatery['coordinates']['latitude']
-    longitude = eatery['coordinates']['longitude']
-  return CoordinatesType(
-      latitude=latitude,
-      longitude=longitude,
-  )
-
-def parse_campus_area(eatery):
-  """Parses the common name location of an eatery.
-
-  Returns a new CampusAreaType that contains a description of an eatery
-
-  Args:
-      eatery (dict): A valid json dictionary from Cornell Dining that contains eatery information
-  """
-  description, description_short = '', ''
-  if 'campusArea' in eatery:
-    description_short = eatery['campusArea']['descrshort']
-  return CampusAreaType(
-      description_short=description_short
-  )
-
-def parse_static_eateries(static_json):
-  """Parses a static dining json dictionary.
-
-  Similar to the parse_eatery function except for static source. Uses parse_static_op_hours to
-  populate the operating_hours field in a CampusEateryType.
-
-  Args:
-      static_json (dict): A valid dictionary in the format of the dynamic Cornell Dining json for
-        static eateries
-  """
-  for eatery in static_json['eateries']:
-    new_eatery = CampusEateryType(
-        about=eatery.get('about', ''),
-        campus_area=parse_campus_area(eatery),
-        coordinates=parse_coordinates(eatery),
-        eatery_type=parse_eatery_type(eatery),
-        id=eatery.get('id', resolve_id(eatery)),
-        image_url=get_image_url(eatery.get('slug')),
-        location=eatery.get('location', ''),
-        name=eatery.get('name', ''),
-        name_short=eatery.get('nameshort', ''),
-        operating_hours=parse_static_op_hours(
-            eatery.get('operatingHours', []),
-            parse_dining_items(eatery),
-            eatery.get('datesClosed', [])
-        ),
-        payment_methods=parse_payment_methods(eatery.get('payMethods', [])),
-        phone=eatery.get('contactPhone', 'N/A'),
-        slug=eatery.get('slug', '')
-    )
-    campus_eateries[new_eatery.id] = new_eatery
-
-def resolve_id(eatery, collegetown=False):
-  """Returns a new id (int) for an external eatery
-  If the eatery does not have a provided id, we need to create one.
-  Since all provided eatery ID values are positive, we decrement starting at 0.
-  """
-  if not collegetown and 'id' in eatery:
-    return eatery['id']
-  elif eatery['name'] in static_eateries:
-    return static_eateries['id']
-
-  static_eateries[eatery['name']] = -1 * len(static_eateries)
-  return -1 * len(static_eateries)
-
-def parse_eatery_type(eatery):
-  """Parses the classification of an eatery.
-
-  Returns the type of an eatery (dining hall, cafe, etc).
-
-  Args:
-      eatery (dict): A valid json dictionary from Cornell Dining that contains eatery information
-  """
-  try:
-    return eatery['eateryTypes'][0]['descr']
-  except Exception:
-    return 'Unknown'
-
-def parse_static_op_hours(hours_list, dining_items, dates_closed):
-  """Parses the hours of a static eatery.
-
-  Returns a list with an OperatingHoursType, similar to parse_operating_hours, but includes
-  checking for dates the eatery is closed.
-
-  Args:
-      hours_list (list): A list containing the days a static eatery is open
-      dining_items (list): A list that holds a dictionary for the items an eatery serves and a flag
-       for healthy options
-      dates_closed (list): A list containg all the dates that an eatery is closed outside of its
-        weekly schedule
-  """
-  weekdays = {}
-  for hours in hours_list:
-    if '-' in hours['weekday']:
-      start, end = hours['weekday'].split('-')
-      start_index = WEEKDAYS[start]
-      end_index = WEEKDAYS[end] + 1
-      days = list(range(start_index, end_index))
-    else:
-      days = [WEEKDAYS[hours['weekday']]]
-    for weekday in days:
-      if weekday not in weekdays:
-        weekdays[weekday] = hours['events']
-
-  new_operating_hours = []
-  for i in range(NUM_DAYS_STORED_IN_DB):
-    new_date = today + timedelta(days=i)
-    for dates in dates_closed:
-      if '-' not in dates:
-        closed_date = datetime.strptime(dates, '%m/%d/%y').date()
-        if new_date == closed_date:
-          break
-      else:
-        start_str, end_str = dates.split('-')
-        start_date = datetime.strptime(start_str, '%m/%d/%y').date()
-        end_date = datetime.strptime(end_str, '%m/%d/%y').date()
-        if start_date <= new_date <= end_date:
-          break
-    else:
-      # new_date is not present in dates_closed, we can add this date to the db
-      new_events = weekdays.get(new_date.weekday(), [])
-      for event in new_events:
-        event['menu'] = dining_items
-
-      new_operating_hours.append(
-          OperatingHoursType(
-              date=new_date.isoformat(),
-              events=parse_events(new_events, new_date.isoformat())
-          )
-      )
-  return new_operating_hours
-
-def format_time(start_time, end_time, start_date, hr24=False, overnight=False):
-  """Returns a formatted time concatenated with date (string) for an eatery event
-  Input comes in two forms depending on if it is collegetown eatery (24hr format).
-  Some end times are 'earlier' than the start time, indicating we have rolled over to a new day.
-  """
-  if hr24:
-    start = datetime.strptime(start_time, '%H%M')
-    start_time = start.strftime('%I:%M%p')
-    end = datetime.strptime(end_time, '%H%M')
-    end_time = end.strftime('%I:%M%p')
-
-  else:
-    start = datetime.strptime(start_time, '%H:%M%p')
-    start_time = start.strftime('%I:%M') + start_time[-2:].upper()
-    end = datetime.strptime(end_time, '%I:%M%p')
-    end_time = end.strftime('%I:%M') + end_time[-2:].upper()
-
-  end_date = start_date
-  if overnight or (end.strftime('%p') == 'AM' and end < start):
-    year, month, day = start_date.split('-')
-    next_day = date(int(year), int(month), int(day)) + timedelta(days=1)
-    end_date = next_day.isoformat()
-
-  new_start = "{}:{}".format(start_date, start_time)
-  new_end = "{}:{}".format(end_date, end_time)
-
-  return [new_start, new_end]
-
-def get_trillium_menu():
-  """Gets the Trillium menu.
-
-  Returns the Trillium dining items (using parse_dining_items) from the static json source
-  for menus.
-  """
-  static_json = requests.get(STATIC_MENUS_URL).json()
-  return parse_dining_items(static_json['Trillium'][0])
-
 def merge_hours(eateries):
-   """Merges invalid events with valid events
+  """Merges invalid events with valid events
 
-   Combines events with no menu and a start_time equal to the end_time of a previous event into
-   one event. This removes the effectively removes the events with no menus and only preserves
-   the end time of the invalid event.
+  Combines events with no menu and a start_time equal to the end_time of a previous event into
+  one event. This removes the effectively removes the events with no menus and only preserves
+  the end time of the invalid event.
 
-   Args:
-       eateries (dict): A dictionary containing information provided from Cornell Dining and filled
-         with CampusEateryTypes
-   """
+  Args:
+      eateries (dict): A dictionary containing information provided from Cornell Dining and filled
+      with CampusEateryTypes
+  """
   for eatery in eateries.values():
     for operating_hour in eatery.operating_hours:
       if len(operating_hour.events) <= 1:  # ignore hours that don't have multiple events
@@ -429,87 +72,3 @@ def merge_hours(eateries):
           operating_hour.events.remove(event)
           print('merged events for {} on {}'.format(eatery.name, operating_hour.date))
         base_event = event
-
-def parse_collegetown_eateries(collegetown_data):
-  """Parses Collegetown json dictionary.
-
-  Fills the collegetown_eateries list with objects of type CollegetownEateryType.
-
-  Args:
-      collegetown_data (dict): A valid json dictionary from Yelp that contains eatery information
-  """
-  for eatery in collegetown_data:
-    new_id = resolve_id(eatery, collegetown=True)
-    new_eatery = CollegetownEateryType(
-        address=eatery['location']['address1'],
-        categories=[cuisine['title'] for cuisine in eatery.get('categories', [])],
-        coordinates=parse_coordinates(eatery),
-        eatery_type='Collegetown Restaurant',
-        id=new_id,
-        image_url=eatery.get('image_url', ''),
-        name=eatery.get('name', ''),
-        operating_hours=parse_collegetown_hours(eatery),
-        payment_methods=PaymentMethodsType(
-            brbs=False,
-            cash=True,
-            cornell_card=False,
-            credit=True,
-            swipes=False,
-            mobile=False,
-        ),
-        phone=eatery.get('phone', 'N/A'),
-        price=eatery.get('price', ''),
-        rating=eatery.get('rating', 'N/A'),
-        url=eatery.get('url', ''),
-    )
-    collegetown_eateries[new_eatery.id] = new_eatery
-
-def parse_collegetown_hours(eatery):
-  """Parses the hours of a Collegetown eatery.
-
-  Returns a list of CollegetownHoursType. Calls parse_collegetown_events to fill the events field
-  of CollegetownHoursType.
-
-  Args:
-      eatery (dict): A valid json dictionary from Yelp that contains eatery information
-  """
-  hours_list = eatery.get('hours', [{}])[0].get('open', [])
-  # gets open hours from first dictionary in hours, empty dict-list provided to mimic hours format
-  new_operating_hours = []
-
-  for i in range(NUM_DAYS_STORED_IN_DB):
-    new_date = today + timedelta(days=i)
-    new_events = [event for event in hours_list if event['day'] == new_date.weekday()]
-    new_operating_hours.append(
-        CollegetownHoursType(
-            date=new_date.isoformat(),
-            events=parse_collegetown_events(new_events, new_date.isoformat())
-        )
-    )
-  return new_operating_hours
-
-def parse_collegetown_events(event_list, event_date):
-  """Parses the events in a Collegetown eatery.
-
-  Returns a list of CollegetownEventType.
-
-  Args:
-      event_list (list): Contains a list of times an eatery is open
-      event_date (string): a string representation of the date
-  """
-  new_events = []
-  for event in event_list:
-    start, end = format_time(
-        event.get('start', ''),
-        event.get('end', ''),
-        event_date,
-        hr24=True,
-        overnight=event.get('is_overnight', False)
-    )
-    new_event = CollegetownEventType(
-        description='General',
-        end_time=end,
-        start_time=start,
-    )
-    new_events.append(new_event)
-  return new_events

--- a/src/data.py
+++ b/src/data.py
@@ -37,15 +37,24 @@ static_eateries = {}
 today = date.today()
 
 def start_update():
+  """Starts the data retrieval process.
+
+  Begins the process of getting data for the campus_eateries dictionary,
+  from Cornell Dining and the static source, and collegetown_eateries dictionary,
+  from Yelp.
+  """
   try:
     print('[{}] Updating campus'.format(datetime.now()))
+    # Get data for on-campus, Cornell-owned dining Options
     dining_query = requests.get(CORNELL_DINING_URL)
     data_json = dining_query.json()
     parse_eatery(data_json)
     merge_hours(campus_eateries)
+    # Get data for on-campus, 3rd-party dining options
     static_json = requests.get(STATIC_EATERIES_URL).json()
     parse_static_eateries(static_json)
     Data.update_data(campus_eateries)
+    # Get data for Collegetown eateries
     print('[{}] Updating collegetown'.format(datetime.now()))
     yelp_query = collegetown_search()
     parse_collegetown_eateries(yelp_query)
@@ -56,6 +65,13 @@ def start_update():
     Timer(UPDATE_DELAY, start_update).start()
 
 def parse_eatery(data_json):
+  """Parses a Cornell Dining json dictionary.
+
+  Fills the campus_eateries dictionary with objects of type CampusEateryType.
+
+  Args:
+      data_json (dict): a valid dictionary from the Cornell Dining json
+  """
   for eatery in data_json['data']['eateries']:
     eatery_id = eatery.get('id', resolve_id(eatery))
     dining_items = get_trillium_menu() if eatery_id == TRILLIUM_ID else parse_dining_items(eatery)
@@ -80,9 +96,20 @@ def parse_eatery(data_json):
     campus_eateries[new_eatery.id] = new_eatery
 
 def get_image_url(slug):
+  """Generates a URL for an image.
+
+  Creates a string that represents a url pointing towards the eatery image.
+
+  Args:
+      slug (string): a slugged name of an eatery
+  """
   return "{}{}.jpg".format(IMAGES_URL, slug)
 
 def parse_payment_methods(methods):
+  """Returns a PaymentMethodsType according to which payment methods are available at an eatery.
+  Args:
+      methods (json): a valid json segment for payments from Cornell Dining
+  """
   payment_methods = PaymentMethodsType()
   payment_methods.brbs = any(pay['descrshort'] == PAY_METHODS['brbs'] for pay in methods)
   payment_methods.cash = any(pay['descrshort'] == PAY_METHODS['credit'] for pay in methods)
@@ -93,12 +120,21 @@ def parse_payment_methods(methods):
   return payment_methods
 
 def parse_operating_hours(eatery, dining_items):
+  """Returns a list of OperatingHoursTypes for each dining event for an eatery.
+
+  Calls parse_events to populate the events field for OperatingHoursType.
+
+  Args:
+      eatery (dict): A valid json segment from Cornell Dining that contains eatery information
+      dining_items (list): A list that holds a dictionary for the items an eatery serves and a flag
+       for healthy options
+  """
   new_operating_hours = []
   hours_list = eatery['operatingHours']
   for hours in hours_list:
     new_date = hours.get('date', '')
     hours_events = hours['events']
-
+    #merge the dining items from the json (for non-dining hall eateries) with the menu for an event
     for event in hours_events:
       if not event['menu'] and dining_items:
         event['menu'] = dining_items
@@ -111,6 +147,15 @@ def parse_operating_hours(eatery, dining_items):
   return new_operating_hours
 
 def parse_events(event_list, event_date):
+  """Parses the events of an eatery.
+
+  Returns a list of EventType for each event of an eatery. Calls parse_food_stations to populate
+  the menu field for EventType.
+
+  Args:
+      event_list (list): The list of all events for an eatery
+      event_date (string): The date of all of the events of the eatery
+  """
   new_events = []
   for event in event_list:
     start, end = format_time(event.get('start', ''), event.get('end', ''), event_date)
@@ -125,6 +170,14 @@ def parse_events(event_list, event_date):
   return new_events
 
 def parse_food_stations(station_list):
+  """Parses the food stations available at an event
+
+  Returns a list containing FoodStationTypes for an eatery. Calls parse_food_items to populate
+  the items field for FoodStationType.
+
+  Args:
+      station_list (list): A list representing all of the stations in a dining hall
+  """
   new_stations = []
   if len(station_list) == 1 and not station_list[0]['items']:  # no menu actually provided
     return new_stations
@@ -137,6 +190,14 @@ def parse_food_stations(station_list):
   return new_stations
 
 def parse_food_items(item_list):
+  """Parses the food items available at a food station.
+
+  Returns a list containing FoodItemTypes for an eatery. This is the lowest level that
+  is parsed for a dining hall.
+
+  Args:
+      item_list (list): A list representing the individual food items for each station
+  """
   new_food_items = []
   for item in item_list:
     new_food_items.append(
@@ -148,6 +209,14 @@ def parse_food_items(item_list):
   return new_food_items
 
 def parse_dining_items(eatery):
+  """Parses the dining items of an eatery.
+
+  Returns a list that holds a dictionary for the items an eatery serves and a flag for healthy
+  options. Exclusive to non-dining hall eateries.
+
+  Args:
+      eatery (dict): A valid json dictionary from Cornell Dining that contains eatery information
+  """
   dining_items = {'items': []}
   for item in eatery['diningItems']:
     dining_items['items'].append({
@@ -157,6 +226,13 @@ def parse_dining_items(eatery):
   return [dining_items]
 
 def parse_coordinates(eatery):
+  """Parses the coordinates of an eatery.
+
+  Returns a new CoordinateType that holds the geographic coordinates of an eatery.
+
+  Args:
+      eatery (dict): A valid json dictionary from Cornell Dining that contains eatery information
+  """
   latitude, longitude = 0.0, 0.0
   if 'coordinates' in eatery:
     latitude = eatery['coordinates']['latitude']
@@ -167,6 +243,13 @@ def parse_coordinates(eatery):
   )
 
 def parse_campus_area(eatery):
+  """Parses the common name location of an eatery.
+
+  Returns a new CampusAreaType that contains a description of an eatery
+
+  Args:
+      eatery (dict): A valid json dictionary from Cornell Dining that contains eatery information
+  """
   description, description_short = '', ''
   if 'campusArea' in eatery:
     description_short = eatery['campusArea']['descrshort']
@@ -175,6 +258,15 @@ def parse_campus_area(eatery):
   )
 
 def parse_static_eateries(static_json):
+  """Parses a static dining json dictionary.
+
+  Similar to the parse_eatery function except for static source. Uses parse_static_op_hours to
+  populate the operating_hours field in a CampusEateryType.
+
+  Args:
+      static_json (dict): A valid dictionary in the format of the dynamic Cornell Dining json for
+        static eateries
+  """
   for eatery in static_json['eateries']:
     new_eatery = CampusEateryType(
         about=eatery.get('about', ''),
@@ -211,12 +303,31 @@ def resolve_id(eatery, collegetown=False):
   return -1 * len(static_eateries)
 
 def parse_eatery_type(eatery):
+  """Parses the classification of an eatery.
+
+  Returns the type of an eatery (dining hall, cafe, etc).
+
+  Args:
+      eatery (dict): A valid json dictionary from Cornell Dining that contains eatery information
+  """
   try:
     return eatery['eateryTypes'][0]['descr']
   except Exception:
     return 'Unknown'
 
 def parse_static_op_hours(hours_list, dining_items, dates_closed):
+  """Parses the hours of a static eatery.
+
+  Returns a list with an OperatingHoursType, similar to parse_operating_hours, but includes
+  checking for dates the eatery is closed.
+
+  Args:
+      hours_list (list): A list containing the days a static eatery is open
+      dining_items (list): A list that holds a dictionary for the items an eatery serves and a flag
+       for healthy options
+      dates_closed (list): A list containg all the dates that an eatery is closed outside of its
+        weekly schedule
+  """
   weekdays = {}
   for hours in hours_list:
     if '-' in hours['weekday']:
@@ -287,10 +398,25 @@ def format_time(start_time, end_time, start_date, hr24=False, overnight=False):
   return [new_start, new_end]
 
 def get_trillium_menu():
+  """Gets the Trillium menu.
+
+  Returns the Trillium dining items (using parse_dining_items) from the static json source
+  for menus.
+  """
   static_json = requests.get(STATIC_MENUS_URL).json()
   return parse_dining_items(static_json['Trillium'][0])
 
 def merge_hours(eateries):
+   """Merges invalid events with valid events
+
+   Combines events with no menu and a start_time equal to the end_time of a previous event into
+   one event. This removes the effectively removes the events with no menus and only preserves
+   the end time of the invalid event.
+
+   Args:
+       eateries (dict): A dictionary containing information provided from Cornell Dining and filled
+         with CampusEateryTypes
+   """
   for eatery in eateries.values():
     for operating_hour in eatery.operating_hours:
       if len(operating_hour.events) <= 1:  # ignore hours that don't have multiple events
@@ -304,6 +430,13 @@ def merge_hours(eateries):
         base_event = event
 
 def parse_collegetown_eateries(collegetown_data):
+  """Parses Collegetown json dictionary.
+
+  Fills the collegetown_eateries list with objects of type CollegetownEateryType.
+
+  Args:
+      collegetown_data (dict): A valid json dictionary from Yelp that contains eatery information
+  """
   for eatery in collegetown_data:
     new_id = resolve_id(eatery, collegetown=True)
     new_eatery = CollegetownEateryType(
@@ -331,6 +464,14 @@ def parse_collegetown_eateries(collegetown_data):
     collegetown_eateries[new_eatery.id] = new_eatery
 
 def parse_collegetown_hours(eatery):
+  """Parses the hours of a Collegetown eatery.
+
+  Returns a list of CollegetownHoursType. Calls parse_collegetown_events to fill the events field
+  of CollegetownHoursType.
+
+  Args:
+      eatery (dict): A valid json dictionary from Yelp that contains eatery information
+  """
   hours_list = eatery.get('hours', [{}])[0].get('open', [])
   # gets open hours from first dictionary in hours, empty dict-list provided to mimic hours format
   new_operating_hours = []
@@ -347,6 +488,14 @@ def parse_collegetown_hours(eatery):
   return new_operating_hours
 
 def parse_collegetown_events(event_list, event_date):
+  """Parses the events in a Collegetown eatery.
+
+  Returns a list of CollegetownEventType.
+
+  Args:
+      event_list (list): Contains a list of times an eatery is open
+      event_date (string): a string representation of the date
+  """
   new_events = []
   for event in event_list:
     start, end = format_time(

--- a/src/data.py
+++ b/src/data.py
@@ -296,8 +296,9 @@ def merge_hours(eateries):
       if len(operating_hour.events) <= 1:  # ignore hours that don't have multiple events
         continue
       base_event = operating_hour.events[0]
-      for event in operating_hour.events[:]:  # iterate over copy of list so we can safely remove
-        if event.start_time == base_event.end_time and not event.menu:
+      for event in operating_hour.events[1:]:  # iterate over copy of list so we can safely remove
+        if event.start_time == base_event.end_time and \
+            (not event.menu or event.menu[0].equals(base_event.menu[0])):
           base_event.end_time = event.end_time
           operating_hour.events.remove(event)
           print('merged events for {} on {}'.format(eatery.name, operating_hour.date))

--- a/src/eatery/__init__.py
+++ b/src/eatery/__init__.py
@@ -1,0 +1,5 @@
+from .campus_eatery import parse_eatery
+
+from .collegetown_eatery import parse_collegetown_eateries
+
+from .static_eatery import parse_static_eateries

--- a/src/eatery/campus_eatery.py
+++ b/src/eatery/campus_eatery.py
@@ -1,0 +1,88 @@
+import requests
+
+from src.constants import (
+    STATIC_MENUS_URL,
+    TRILLIUM_ID
+)
+from src.types import (
+    CampusEateryType,
+    OperatingHoursType
+)
+from src.eatery.common_eatery import (
+    get_image_url,
+    parse_campus_area,
+    parse_coordinates,
+    parse_dining_items,
+    parse_eatery_type,
+    parse_events,
+    parse_payment_methods,
+    resolve_id
+)
+
+def parse_eatery(data_json, campus_eateries):
+  """Parses a Cornell Dining json dictionary.
+
+  Fills the campus_eateries dictionary with objects of type CampusEateryType.
+
+  Args:
+      data_json (dict): a valid dictionary from the Cornell Dining json
+      campus_eateries (dict): a dictionary to fill with campus eateries
+  """
+  for eatery in data_json['data']['eateries']:
+    eatery_id = eatery.get('id', resolve_id(eatery))
+    dining_items = get_trillium_menu() if eatery_id == TRILLIUM_ID else parse_dining_items(eatery)
+    phone = eatery.get('contactPhone', 'N/A')
+    phone = phone if phone else 'N/A'  # handle None values
+
+    new_eatery = CampusEateryType(
+        about=eatery.get('about', ''),
+        campus_area=parse_campus_area(eatery),
+        coordinates=parse_coordinates(eatery),
+        eatery_type=parse_eatery_type(eatery),
+        id=eatery_id,
+        image_url=get_image_url(eatery.get('slug', '')),
+        location=eatery.get('location', ''),
+        name=eatery.get('name', ''),
+        name_short=eatery.get('nameshort', ''),
+        operating_hours=parse_operating_hours(eatery, dining_items),
+        payment_methods=parse_payment_methods(eatery['payMethods']),
+        phone=phone,
+        slug=eatery.get('slug', '')
+    )
+    campus_eateries[new_eatery.id] = new_eatery
+
+def get_trillium_menu():
+  """Gets the Trillium menu.
+
+  Returns the Trillium dining items (using parse_dining_items) from the static json source
+  for menus.
+  """
+  static_json = requests.get(STATIC_MENUS_URL).json()
+  return parse_dining_items(static_json['Trillium'][0])
+
+def parse_operating_hours(eatery, dining_items):
+  """Returns a list of OperatingHoursTypes for each dining event for an eatery.
+
+  Calls parse_events to populate the events field for OperatingHoursType.
+
+  Args:
+      eatery (dict): A valid json segment from Cornell Dining that contains eatery information
+      dining_items (list): A list that holds a dictionary for the items an eatery serves and a flag
+       for healthy options
+  """
+  new_operating_hours = []
+  hours_list = eatery['operatingHours']
+  for hours in hours_list:
+    new_date = hours.get('date', '')
+    hours_events = hours['events']
+    #merge the dining items from the json (for non-dining hall eateries) with the menu for an event
+    for event in hours_events:
+      if not event['menu'] and dining_items:
+        event['menu'] = dining_items
+
+    new_operating_hour = OperatingHoursType(
+        date=new_date,
+        events=parse_events(hours_events, new_date)
+    )
+    new_operating_hours.append(new_operating_hour)
+  return new_operating_hours

--- a/src/eatery/collegetown_eatery.py
+++ b/src/eatery/collegetown_eatery.py
@@ -1,0 +1,100 @@
+from datetime import timedelta
+
+from src.constants import NUM_DAYS_STORED_IN_DB
+from src.eatery.common_eatery import (
+    format_time,
+    parse_coordinates,
+    resolve_id,
+    today
+)
+from src.types import (
+    CollegetownEateryType,
+    CollegetownEventType,
+    CollegetownHoursType,
+    PaymentMethodsType
+)
+
+def parse_collegetown_eateries(collegetown_data, collegetown_eateries):
+  """Parses Collegetown json dictionary.
+
+  Fills the collegetown_eateries dictionary with objects of type CollegetownEateryType.
+
+  Args:
+      collegetown_data (dict): A valid json dictionary from Yelp that contains eatery information
+      collegetown_eateries (dict): a dictionary to fill with collegetown eateries
+  """
+  for eatery in collegetown_data:
+    new_id = resolve_id(eatery, collegetown=True)
+    new_eatery = CollegetownEateryType(
+        address=eatery['location']['address1'],
+        categories=[cuisine['title'] for cuisine in eatery.get('categories', [])],
+        coordinates=parse_coordinates(eatery),
+        eatery_type='Collegetown Restaurant',
+        id=new_id,
+        image_url=eatery.get('image_url', ''),
+        name=eatery.get('name', ''),
+        operating_hours=parse_collegetown_hours(eatery),
+        payment_methods=PaymentMethodsType(
+            brbs=False,
+            cash=True,
+            cornell_card=False,
+            credit=True,
+            swipes=False,
+            mobile=False,
+        ),
+        phone=eatery.get('phone', 'N/A'),
+        price=eatery.get('price', ''),
+        rating=eatery.get('rating', 'N/A'),
+        url=eatery.get('url', ''),
+    )
+    collegetown_eateries[new_eatery.id] = new_eatery
+
+def parse_collegetown_hours(eatery):
+  """Parses the hours of a Collegetown eatery.
+
+  Returns a list of CollegetownHoursType. Calls parse_collegetown_events to fill the events field
+  of CollegetownHoursType.
+
+  Args:
+      eatery (dict): A valid json dictionary from Yelp that contains eatery information
+  """
+  hours_list = eatery.get('hours', [{}])[0].get('open', [])
+  # gets open hours from first dictionary in hours, empty dict-list provided to mimic hours format
+  new_operating_hours = []
+
+  for i in range(NUM_DAYS_STORED_IN_DB):
+    new_date = today + timedelta(days=i)
+    new_events = [event for event in hours_list if event['day'] == new_date.weekday()]
+    new_operating_hours.append(
+        CollegetownHoursType(
+            date=new_date.isoformat(),
+            events=parse_collegetown_events(new_events, new_date.isoformat())
+        )
+    )
+  return new_operating_hours
+
+def parse_collegetown_events(event_list, event_date):
+  """Parses the events in a Collegetown eatery.
+
+  Returns a list of CollegetownEventType.
+
+  Args:
+      event_list (list): Contains a list of times an eatery is open
+      event_date (string): a string representation of the date
+  """
+  new_events = []
+  for event in event_list:
+    start, end = format_time(
+        event.get('start', ''),
+        event.get('end', ''),
+        event_date,
+        hr24=True,
+        overnight=event.get('is_overnight', False)
+    )
+    new_event = CollegetownEventType(
+        description='General',
+        end_time=end,
+        start_time=start,
+    )
+    new_events.append(new_event)
+  return new_events

--- a/src/eatery/common_eatery.py
+++ b/src/eatery/common_eatery.py
@@ -1,0 +1,206 @@
+from datetime import date, datetime, timedelta
+
+from src.constants import (
+    IMAGES_URL,
+    PAY_METHODS
+)
+from src.types import (
+    CampusAreaType,
+    CoordinatesType,
+    EventType,
+    FoodItemType,
+    FoodStationType,
+    PaymentMethodsType
+)
+
+today = date.today()
+static_eateries = {}
+
+def parse_campus_area(eatery):
+  """Parses the common name location of an eatery.
+
+  Returns a new CampusAreaType that contains a description of an eatery
+
+  Args:
+      eatery (dict): A valid json dictionary from Cornell Dining that contains eatery information
+  """
+  if 'campusArea' in eatery:
+    description_short = eatery['campusArea']['descrshort']
+  return CampusAreaType(
+      description_short=description_short
+  )
+
+def parse_coordinates(eatery):
+  """Parses the coordinates of an eatery.
+
+  Returns a new CoordinateType that holds the geographic coordinates of an eatery.
+
+  Args:
+      eatery (dict): A valid json dictionary from Cornell Dining that contains eatery information
+  """
+  latitude, longitude = 0.0, 0.0
+  if 'coordinates' in eatery:
+    latitude = eatery['coordinates']['latitude']
+    longitude = eatery['coordinates']['longitude']
+  return CoordinatesType(
+      latitude=latitude,
+      longitude=longitude,
+  )
+
+def parse_dining_items(eatery):
+  """Parses the dining items of an eatery.
+
+  Returns a list that holds a dictionary for the items an eatery serves and a flag for healthy
+  options. Exclusive to non-dining hall eateries.
+
+  Args:
+      eatery (dict): A valid json dictionary from Cornell Dining that contains eatery information
+  """
+  dining_items = {'items': []}
+  for item in eatery['diningItems']:
+    dining_items['items'].append({
+        'healthy': item.get('healthy', False),
+        'item': item.get('item', '')
+    })
+  return [dining_items]
+
+def parse_eatery_type(eatery):
+  """Parses the classification of an eatery.
+
+  Returns the type of an eatery (dining hall, cafe, etc).
+
+  Args:
+      eatery (dict): A valid json dictionary from Cornell Dining that contains eatery information
+  """
+  try:
+    return eatery['eateryTypes'][0]['descr']
+  except Exception:
+    return 'Unknown'
+
+def parse_events(event_list, event_date):
+  """Parses the events of an eatery.
+
+  Returns a list of EventType for each event of an eatery. Calls parse_food_stations to populate
+  the menu field for EventType.
+
+  Args:
+      event_list (list): The list of all events for an eatery
+      event_date (string): The date of all of the events of the eatery
+  """
+  new_events = []
+  for event in event_list:
+    start, end = format_time(event.get('start', ''), event.get('end', ''), event_date)
+    new_event = EventType(
+        cal_summary=event.get('calSummary', ''),
+        description=event.get('descr', ''),
+        end_time=end,
+        menu=parse_food_stations(event.get('menu', [])),
+        start_time=start
+    )
+    new_events.append(new_event)
+  return new_events
+
+def parse_payment_methods(methods):
+  """Returns a PaymentMethodsType according to which payment methods are available at an eatery.
+
+  Args:
+      methods (json): a valid json segment for payments from Cornell Dining
+  """
+  payment_methods = PaymentMethodsType()
+  payment_methods.brbs = any(pay['descrshort'] == PAY_METHODS['brbs'] for pay in methods)
+  payment_methods.cash = any(pay['descrshort'] == PAY_METHODS['credit'] for pay in methods)
+  payment_methods.credit = any(pay['descrshort'] == PAY_METHODS['credit'] for pay in methods)
+  payment_methods.cornell_card = any(pay['descrshort'] == PAY_METHODS['c-card'] for pay in methods)
+  payment_methods.mobile = any(pay['descrshort'] == PAY_METHODS['mobile'] for pay in methods)
+  payment_methods.swipes = any(pay['descrshort'] == PAY_METHODS['swipes'] for pay in methods)
+  return payment_methods
+
+def parse_food_stations(station_list):
+  """Parses the food stations available at an event
+
+  Returns a list containing FoodStationTypes for an eatery. Calls parse_food_items to populate
+  the items field for FoodStationType.
+
+  Args:
+      station_list (list): A list representing all of the stations in a dining hall
+  """
+  new_stations = []
+  if len(station_list) == 1 and not station_list[0]['items']:  # no menu actually provided
+    return new_stations
+  for station in station_list:
+    new_station = FoodStationType(
+        category=station.get('category', ''),
+        items=parse_food_items(station.get('items', []))
+    )
+    new_stations.append(new_station)
+  return new_stations
+
+def parse_food_items(item_list):
+  """Parses the food items available at a food station.
+
+  Returns a list containing FoodItemTypes for an eatery. This is the lowest level that
+  is parsed for a dining hall.
+
+  Args:
+      item_list (list): A list representing the individual food items for each station
+  """
+  new_food_items = []
+  for item in item_list:
+    new_food_items.append(
+        FoodItemType(
+            healthy=item.get('healthy', False),
+            item=item.get('item', '')
+        )
+    )
+  return new_food_items
+
+def resolve_id(eatery, collegetown=False, ):
+  """Returns a new id (int) for an external eatery
+  If the eatery does not have a provided id, we need to create one.
+  Since all provided eatery ID values are positive, we decrement starting at 0.
+  """
+  if not collegetown and 'id' in eatery:
+    return eatery['id']
+  elif eatery['name'] in static_eateries:
+    return static_eateries['id']
+
+  static_eateries[eatery['name']] = -1 * len(static_eateries)
+  return -1 * len(static_eateries)
+
+def get_image_url(slug):
+  """Generates a URL for an image.
+
+  Creates a string that represents a url pointing towards the eatery image.
+
+  Args:
+      slug (string): a slugged name of an eatery
+  """
+  return "{}{}.jpg".format(IMAGES_URL, slug)
+
+def format_time(start_time, end_time, start_date, hr24=False, overnight=False):
+  """Returns a formatted time concatenated with date (string) for an eatery event
+  Input comes in two forms depending on if it is collegetown eatery (24hr format).
+  Some end times are 'earlier' than the start time, indicating we have rolled over to a new day.
+  """
+  if hr24:
+    start = datetime.strptime(start_time, '%H%M')
+    start_time = start.strftime('%I:%M%p')
+    end = datetime.strptime(end_time, '%H%M')
+    end_time = end.strftime('%I:%M%p')
+
+  else:
+    start = datetime.strptime(start_time, '%H:%M%p')
+    start_time = start.strftime('%I:%M') + start_time[-2:].upper()
+    end = datetime.strptime(end_time, '%I:%M%p')
+    end_time = end.strftime('%I:%M') + end_time[-2:].upper()
+
+  end_date = start_date
+  if overnight or (end.strftime('%p') == 'AM' and end < start):
+    year, month, day = start_date.split('-')
+    next_day = date(int(year), int(month), int(day)) + timedelta(days=1)
+    end_date = next_day.isoformat()
+
+  new_start = "{}:{}".format(start_date, start_time)
+  new_end = "{}:{}".format(end_date, end_time)
+
+  return [new_start, new_end]

--- a/src/eatery/static_eatery.py
+++ b/src/eatery/static_eatery.py
@@ -1,0 +1,108 @@
+from datetime import datetime, timedelta
+
+from src.constants import (
+    NUM_DAYS_STORED_IN_DB,
+    WEEKDAYS
+)
+from src.eatery.common_eatery import (
+    get_image_url,
+    parse_campus_area,
+    parse_coordinates,
+    parse_dining_items,
+    parse_eatery_type,
+    parse_events,
+    parse_payment_methods,
+    resolve_id,
+    today
+)
+from src.types import (
+    CampusEateryType,
+    OperatingHoursType
+)
+
+def parse_static_eateries(static_json, campus_eateries):
+  """Parses a static dining json dictionary.
+
+  Similar to the parse_eatery function except for static source. Uses parse_static_op_hours to
+  populate the operating_hours field in a CampusEateryType.
+
+  Args:
+      static_json (dict): A valid dictionary in the format of the dynamic Cornell Dining json for
+        static eateries
+      campus_eateries (dict): A dictionary to fill with static eateries
+  """
+  for eatery in static_json['eateries']:
+    new_eatery = CampusEateryType(
+        about=eatery.get('about', ''),
+        campus_area=parse_campus_area(eatery),
+        coordinates=parse_coordinates(eatery),
+        eatery_type=parse_eatery_type(eatery),
+        id=eatery.get('id', resolve_id(eatery)),
+        image_url=get_image_url(eatery.get('slug')),
+        location=eatery.get('location', ''),
+        name=eatery.get('name', ''),
+        name_short=eatery.get('nameshort', ''),
+        operating_hours=parse_static_op_hours(
+            eatery.get('operatingHours', []),
+            parse_dining_items(eatery),
+            eatery.get('datesClosed', [])
+        ),
+        payment_methods=parse_payment_methods(eatery.get('payMethods', [])),
+        phone=eatery.get('contactPhone', 'N/A'),
+        slug=eatery.get('slug', '')
+    )
+    campus_eateries[new_eatery.id] = new_eatery
+
+def parse_static_op_hours(hours_list, dining_items, dates_closed):
+  """Parses the hours of a static eatery.
+
+  Returns a list with an OperatingHoursType, similar to parse_operating_hours, but includes
+  checking for dates the eatery is closed.
+
+  Args:
+      hours_list (list): A list containing the days a static eatery is open
+      dining_items (list): A list that holds a dictionary for the items an eatery serves and a flag
+       for healthy options
+      dates_closed (list): A list containg all the dates that an eatery is closed outside of its
+        weekly schedule
+  """
+  weekdays = {}
+  for hours in hours_list:
+    if '-' in hours['weekday']:
+      start, end = hours['weekday'].split('-')
+      start_index = WEEKDAYS[start]
+      end_index = WEEKDAYS[end] + 1
+      days = list(range(start_index, end_index))
+    else:
+      days = [WEEKDAYS[hours['weekday']]]
+    for weekday in days:
+      if weekday not in weekdays:
+        weekdays[weekday] = hours['events']
+
+  new_operating_hours = []
+  for i in range(NUM_DAYS_STORED_IN_DB):
+    new_date = today + timedelta(days=i)
+    for dates in dates_closed:
+      if '-' not in dates:
+        closed_date = datetime.strptime(dates, '%m/%d/%y').date()
+        if new_date == closed_date:
+          break
+      else:
+        start_str, end_str = dates.split('-')
+        start_date = datetime.strptime(start_str, '%m/%d/%y').date()
+        end_date = datetime.strptime(end_str, '%m/%d/%y').date()
+        if start_date <= new_date <= end_date:
+          break
+    else:
+      # new_date is not present in dates_closed, we can add this date to the db
+      new_events = weekdays.get(new_date.weekday(), [])
+      for event in new_events:
+        event['menu'] = dining_items
+
+      new_operating_hours.append(
+          OperatingHoursType(
+              date=new_date.isoformat(),
+              events=parse_events(new_events, new_date.isoformat())
+          )
+      )
+  return new_operating_hours

--- a/src/types/food_station_type.py
+++ b/src/types/food_station_type.py
@@ -4,6 +4,16 @@ class FoodItemType(ObjectType):
   item = String(required=True)
   healthy = Boolean(required=True)
 
+  def equals(self, food_item):
+    return self.item == food_item.item and self.healthy == food_item.healthy
+
 class FoodStationType(ObjectType):
   category = String(required=True)
   items = List(FoodItemType, required=True)
+
+  def equals(self, food_station):
+    num_items = len(self.items)
+    if num_items != len(food_station.items):
+      return False
+    # check if each item in menu equals the item in other menu
+    return all([self.items[i].equals(food_station.items[i]) for i in range(num_items)])


### PR DESCRIPTION
Now all parsing related methods have docstrings included.  Also includes a file restructure to split the parsing of our three different information routes (cornell dining, externalEateries.json, yelp api) across their own individual files to keep our main data.py file as clean as possible.  Also includes a fix on merging events for an eatery to include the case where the exact same menus are being provided.  

Note: This will also be used as an attempt to fix the weird date troubles we are currently having with the static and ctown eateries by restarting the db.