### PR TITLE
Fix failed yelp requests

### DIFF
--- a/src/collegetown.py
+++ b/src/collegetown.py
@@ -31,3 +31,4 @@ def collegetown_search():
     return eateries
   except Exception as e:
     print(e)
+    return []

--- a/src/data.py
+++ b/src/data.py
@@ -44,6 +44,7 @@ def start_update():
     yelp_query = collegetown_search()
     parse_collegetown_eateries(yelp_query, collegetown_eateries)
     Data.update_collegetown_data(collegetown_eateries)
+    print('[{}] All data updated, waiting for requests'.format(datetime.now()))
   except Exception as e:
     print('Data update failed:', e)
   finally:


### PR DESCRIPTION
If our yelp requests crashed, we would not return anything back and cause NoneType errors.  Returning an empty list fixes this issue, but a more thorough investigation into yelp will be continued (although I could not recreate the error on my machine, unfortunately).  