### PR TITLE
Fix merging of events

### DIFF
--- a/src/data.py
+++ b/src/data.py
@@ -68,10 +68,11 @@ def merge_hours(eateries):
       base_event = operating_hour.events[0]
       for event in operating_hour.events[1:]:  # iterate over copy of list so we can safely remove
         if (event.start_time == base_event.end_time and
-            event.menu and
             base_event.menu and
-            event.menu[0].equals(base_event.menu[0])):
+            (not event.menu or
+            event.menu[0].equals(base_event.menu[0]))):
           base_event.end_time = event.end_time
           operating_hour.events.remove(event)
           print('merged events for {} on {}'.format(eatery.name, operating_hour.date))
-        base_event = event
+        else:
+          base_event = event


### PR DESCRIPTION
If we have two events like this where the second event's menu is empty, they don't actually get combined. I changed it so that if the second event **does** have a menu then it checks for equality. So if the second doesn't have a menu it will default to the previous event's one.

<img width="459" alt="Screen Shot 2019-03-26 at 6 32 34 PM" src="https://user-images.githubusercontent.com/22579863/55038362-f7d52180-4ff6-11e9-857c-9dfb86aa673e.png">
