### PR TITLE
Change brb history timestamps and fix eatery names

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -11,6 +11,32 @@ GET_URL = 'https://services.get.cbord.com/GETServices/services/json'
 GIT_CONTENT_URL = 'https://raw.githubusercontent.com/cuappdev'
 IGNORE_LOCATIONS = ['BS-No Bill Workstation', 'Admin Workstation (B)']
 IMAGES_URL = GIT_CONTENT_URL + '/assets/master/eatery/eatery-images/'
+LOCATION_NAMES = {
+    'Alice Cook House': 'Cook House Dining Room',
+    'Attrium Cafe': 'Atrium Café',
+    'Cafe Jennie': 'Café Jennie',
+    'Carl Becker House': 'Becker House Dining Room',
+    'Carols Cafe': "Carol's Café",
+    'Duffield': "Mattin's Café",
+    "Franny's FT": "Franny's",
+    "Goldies Cafe": "Goldie's Café",
+    'Jansens at Bethe House': "Jansen's Dining Room at Bethe House",
+    'Jansens Market': "Jansen's Market",
+    'Keeton House': 'Keeton House Dining Room',
+    'Kosher': '104West!',
+    'Marthas': "Martha's Express",
+    "McCormick's": "McCormick's at Moakley House",
+    'North Star Marketplace': 'North Star Dining Room',
+    'Olin Libe Cafe': 'Amit Bhatia Libe Café',
+    'RPME': 'Robert Purcell Marketplace Eatery',
+    'Risley': 'Risley Dining Room',
+    'Rose House': 'Rose House Dining Room',
+    'Rustys': "Rusty's",
+    'Sage': 'Atrium Café',
+    'Statler Macs': "Mac's Café",
+    'Statler Terrace': 'The Terrace',
+    'Straight Market': 'Straight from the Market',
+}
 NUM_DAYS_STORED_IN_DB = 8
 PAY_METHODS = {
     'brbs': 'Meal Plan - Debit',

--- a/src/schema.py
+++ b/src/schema.py
@@ -11,6 +11,7 @@ from src.constants import (
     CORNELL_INSTITUTION_ID,
     GET_URL,
     IGNORE_LOCATIONS,
+    LOCATION_NAMES,
     SWIPE_PLANS,
 )
 from src.types import (
@@ -136,17 +137,17 @@ class Query(ObjectType):
 
     account_info['history'] = []
 
-    for t in transactions:
-      if ACCOUNT_NAMES['brbs'] not in t['accountName'] or t['locationName'] in IGNORE_LOCATIONS:
+    for txn in transactions:
+      if ACCOUNT_NAMES['brbs'] not in txn['accountName'] or txn['locationName'] in IGNORE_LOCATIONS:
         continue
-      dt_utc = parser.parse(t['actualDate']).astimezone(pytz.timezone('UTC'))
-      dt_est = dt_utc.astimezone(pytz.timezone('US/Eastern'))
+      txn_timestamp = parser.parse(txn['actualDate']).astimezone(pytz.timezone('US/Eastern'))
+      location = txn['locationName'].rsplit(' ', 1)[0]
+      # removes the register numbers at the end of the string by taking the substring up until
+      # the last space (right before the number)
       new_transaction = {
-          'amount': t['amount'],
-          'name': t['locationName'][:t['locationName'].rfind(' ')],
-          # removes the register numbers at the end of the string by taking the substring up until
-          # the last space (right before the number)
-          'timestamp': dt_est.strftime("%D at %I:%M %p")
+          'amount': txn['amount'],
+          'name': LOCATION_NAMES.get(location, location),
+          'timestamp': txn_timestamp.strftime("%A, %b %d at %I:%M %p")
       }
       account_info['history'].append(TransactionType(**new_transaction))
 


### PR DESCRIPTION
timestamps for brb transactions now read as <weekday>, <shortened month> <day number> at <HH:MM> AM/PM.

GET also was giving cryptic dining hall names (ex: "Duffield", "Statler Macs", "RPME", etc.) that are changed to reflect the names the same as Cornell Dining Now.