### PR TITLE
Add Enums for PaymentMethods and Ratings 

### DIFF
--- a/src/eatery/campus_eatery.py
+++ b/src/eatery/campus_eatery.py
@@ -16,6 +16,7 @@ from src.eatery.common_eatery import (
     parse_eatery_type,
     parse_events,
     parse_payment_methods,
+    parse_payment_methods_enum,
     resolve_id
 )
 
@@ -46,6 +47,7 @@ def parse_eatery(data_json, campus_eateries):
         name_short=eatery.get('nameshort', ''),
         operating_hours=parse_operating_hours(eatery, dining_items),
         payment_methods=parse_payment_methods(eatery['payMethods']),
+        payment_methods_enums=parse_payment_methods_enum(eatery.get('payMethods', [])),
         phone=phone,
         slug=eatery.get('slug', '')
     )

--- a/src/eatery/collegetown_eatery.py
+++ b/src/eatery/collegetown_eatery.py
@@ -11,7 +11,9 @@ from src.types import (
     CollegetownEateryType,
     CollegetownEventType,
     CollegetownHoursType,
-    PaymentMethodsType
+    PaymentMethodsEnum,
+    PaymentMethodsType,
+    RatingEnum
 )
 
 def parse_collegetown_eateries(collegetown_data, collegetown_eateries):
@@ -42,9 +44,11 @@ def parse_collegetown_eateries(collegetown_data, collegetown_eateries):
             swipes=False,
             mobile=False,
         ),
+        payment_methods_enums=[PaymentMethodsEnum.CASH, PaymentMethodsEnum.CREDIT],
         phone=eatery.get('phone', 'N/A'),
         price=eatery.get('price', ''),
         rating=eatery.get('rating', 'N/A'),
+        rating_enum=parse_rating(eatery),
         url=eatery.get('url', ''),
     )
     collegetown_eateries[new_eatery.id] = new_eatery
@@ -98,3 +102,15 @@ def parse_collegetown_events(event_list, event_date):
     )
     new_events.append(new_event)
   return new_events
+
+def parse_rating(eatery):
+  """Parses the rating of a Collegetown eatery.
+
+  Returns the corresponding rating name according to the RatingEnum.
+
+  Args:
+      eatery (dict): A valid json dictionary from Yelp that contains eatery information
+  """
+  rating = eatery.get('rating', 'N/A')
+  index = int(round(float(rating) * 2))
+  return RatingEnum.get(index)

--- a/src/eatery/common_eatery.py
+++ b/src/eatery/common_eatery.py
@@ -10,6 +10,7 @@ from src.types import (
     EventType,
     FoodItemType,
     FoodStationType,
+    PaymentMethodsEnum,
     PaymentMethodsType
 )
 
@@ -113,6 +114,29 @@ def parse_payment_methods(methods):
   payment_methods.cornell_card = any(pay['descrshort'] == PAY_METHODS['c-card'] for pay in methods)
   payment_methods.mobile = any(pay['descrshort'] == PAY_METHODS['mobile'] for pay in methods)
   payment_methods.swipes = any(pay['descrshort'] == PAY_METHODS['swipes'] for pay in methods)
+  return payment_methods
+
+def parse_payment_methods_enum(methods):
+  """Returns a PaymentMethoddsEnumType according to which payment methods are available at an
+  eatery.
+
+  Args:
+      methods (json): a valid json segment for payments from Cornell Dining
+  """
+  payment_methods = []
+  for method in methods:
+    description = method['descrshort']
+    if (description == PAY_METHODS['brbs']):
+      payment_methods.append(PaymentMethodsEnum.BRB)
+    if (description == PAY_METHODS['credit']):
+      payment_methods.append(PaymentMethodsEnum.CASH)
+      payment_methods.append(PaymentMethodsEnum.CREDIT)
+    if (description == PAY_METHODS['c-card']):
+      payment_methods.append(PaymentMethodsEnum.CORNELL_CARD)
+    if (description == PAY_METHODS['mobile']):
+      payment_methods.append(PaymentMethodsEnum.MOBILE)
+    if (description == PAY_METHODS['swipes']):
+      payment_methods.append(PaymentMethodsEnum.SWIPES)
   return payment_methods
 
 def parse_food_stations(station_list):

--- a/src/eatery/static_eatery.py
+++ b/src/eatery/static_eatery.py
@@ -12,6 +12,7 @@ from src.eatery.common_eatery import (
     parse_eatery_type,
     parse_events,
     parse_payment_methods,
+    parse_payment_methods_enum,
     resolve_id,
     today
 )
@@ -48,6 +49,7 @@ def parse_static_eateries(static_json, campus_eateries):
             eatery.get('datesClosed', [])
         ),
         payment_methods=parse_payment_methods(eatery.get('payMethods', [])),
+        payment_methods_enums=parse_payment_methods_enum(eatery.get('payMethods', [])),
         phone=eatery.get('contactPhone', 'N/A'),
         slug=eatery.get('slug', '')
     )

--- a/src/types/__init__.py
+++ b/src/types/__init__.py
@@ -4,6 +4,7 @@ from .eatery_type import (
     CampusEateryType,
     CollegetownEateryType,
     CoordinatesType,
+    RatingEnum
 )
 from .food_station_type import FoodItemType, FoodStationType
 from .operating_hours_type import (
@@ -12,4 +13,4 @@ from .operating_hours_type import (
     EventType,
     OperatingHoursType,
 )
-from .payment_methods_type import PaymentMethodsType
+from .payment_methods_type import PaymentMethodsEnum, PaymentMethodsType

--- a/src/types/eatery_type.py
+++ b/src/types/eatery_type.py
@@ -1,7 +1,7 @@
-from graphene import Field, Float, Int, List, ObjectType, String
+from graphene import Enum, Field, Float, Int, List, ObjectType, String
 
 from src.types.operating_hours_type import OperatingHoursType, CollegetownHoursType
-from src.types.payment_methods_type import PaymentMethodsType
+from src.types.payment_methods_type import PaymentMethodsEnum, PaymentMethodsType
 
 class CampusAreaType(ObjectType):
   description_short = String(required=True)
@@ -10,6 +10,18 @@ class CoordinatesType(ObjectType):
   latitude = Float(required=True)
   longitude = Float(required=True)
 
+class RatingEnum(Enum):
+  # represents a rating on a 1-5 scale with the constants representing double the rating value
+  ONE = 2
+  ONE_HALF = 3
+  TWO = 4
+  TWO_HALF = 5
+  THREE = 6
+  THREE_HALF = 7
+  FOUR = 8
+  FOUR_HALF = 9
+  FIVE = 10
+
 class EateryBaseType(ObjectType):
   coordinates = Field(CoordinatesType, required=True)
   eatery_type = String(required=True)
@@ -17,6 +29,7 @@ class EateryBaseType(ObjectType):
   image_url = String(required=True)
   name = String(required=True)
   payment_methods = Field(PaymentMethodsType, required=True)
+  payment_methods_enums = List(PaymentMethodsEnum, required=True)
   phone = String(required=True)
 
 class CampusEateryType(EateryBaseType):
@@ -33,4 +46,5 @@ class CollegetownEateryType(EateryBaseType):
   operating_hours = List(CollegetownHoursType, required=True)
   price = String(required=True)
   rating = String(required=True)
+  rating_enum = Field(RatingEnum, required=True)
   url = String(required=True)

--- a/src/types/payment_methods_type.py
+++ b/src/types/payment_methods_type.py
@@ -1,4 +1,12 @@
-from graphene import Boolean, ObjectType
+from graphene import Boolean, Enum, ObjectType
+
+class PaymentMethodsEnum(Enum):
+  BRB = 0
+  CASH = 1
+  CORNELL_CARD = 2
+  CREDIT = 3
+  MOBILE = 4
+  SWIPES = 5
 
 class PaymentMethodsType(ObjectType):
   brbs = Boolean(required=True)


### PR DESCRIPTION
Create a new field in eatery and Collegetown eatery types for payment methods that uses an Enum, and a new field only for the Collegetown eatery type for ratings that also uses an Enum.