### PR TITLE
Add graceful_timeout to gunicorn and fix resolve_id

### DIFF
--- a/src/eatery/common_eatery.py
+++ b/src/eatery/common_eatery.py
@@ -154,7 +154,7 @@ def parse_food_items(item_list):
     )
   return new_food_items
 
-def resolve_id(eatery, collegetown=False, ):
+def resolve_id(eatery, collegetown=False):
   """Returns a new id (int) for an external eatery
   If the eatery does not have a provided id, we need to create one.
   Since all provided eatery ID values are positive, we decrement starting at 0.
@@ -162,10 +162,10 @@ def resolve_id(eatery, collegetown=False, ):
   if not collegetown and 'id' in eatery:
     return eatery['id']
   elif eatery['name'] in static_eateries:
-    return static_eateries['id']
-
-  static_eateries[eatery['name']] = -1 * len(static_eateries)
-  return -1 * len(static_eateries)
+    return static_eateries[eatery['name']]
+  new_id = -1 * len(static_eateries)
+  static_eateries[eatery['name']] = new_id
+  return new_id
 
 def get_image_url(slug):
   """Generates a URL for an image.

--- a/start_server.sh
+++ b/start_server.sh
@@ -1,1 +1,1 @@
-gunicorn -w 4 -t 60 -b 0.0.0.0:5000 app:app
+gunicorn -w 4 -t 60 --graceful_timeout 60 -b 0.0.0.0:5000 app:app


### PR DESCRIPTION
resolve_id was causing crashes when updating static eateries because of an attempt to use a nonexistent key.  Fixing up this method should prevent crashes and the graceful_timout increase to match the current timeout setting should prevent an infinite loop of worker timeouts :)