### PR TITLE
Fix event merging, GET information, resolve_id method

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -11,6 +11,32 @@ GET_URL = 'https://services.get.cbord.com/GETServices/services/json'
 GIT_CONTENT_URL = 'https://raw.githubusercontent.com/cuappdev'
 IGNORE_LOCATIONS = ['BS-No Bill Workstation', 'Admin Workstation (B)']
 IMAGES_URL = GIT_CONTENT_URL + '/assets/master/eatery/eatery-images/'
+LOCATION_NAMES = {
+    'Alice Cook House': 'Cook House Dining Room',
+    'Attrium Cafe': 'Atrium Café',
+    'Cafe Jennie': 'Café Jennie',
+    'Carl Becker House': 'Becker House Dining Room',
+    'Carols Cafe': "Carol's Café",
+    'Duffield': "Mattin's Café",
+    "Franny's FT": "Franny's",
+    "Goldies Cafe": "Goldie's Café",
+    'Jansens at Bethe House': "Jansen's Dining Room at Bethe House",
+    'Jansens Market': "Jansen's Market",
+    'Keeton House': 'Keeton House Dining Room',
+    'Kosher': '104West!',
+    'Marthas': "Martha's Express",
+    "McCormick's": "McCormick's at Moakley House",
+    'North Star Marketplace': 'North Star Dining Room',
+    'Olin Libe Cafe': 'Amit Bhatia Libe Café',
+    'RPME': 'Robert Purcell Marketplace Eatery',
+    'Risley': 'Risley Dining Room',
+    'Rose House': 'Rose House Dining Room',
+    'Rustys': "Rusty's",
+    'Sage': 'Atrium Café',
+    'Statler Macs': "Mac's Café",
+    'Statler Terrace': 'The Terrace',
+    'Straight Market': 'Straight from the Market',
+}
 NUM_DAYS_STORED_IN_DB = 8
 PAY_METHODS = {
     'brbs': 'Meal Plan - Debit',

--- a/src/constants.py
+++ b/src/constants.py
@@ -27,7 +27,7 @@ LOCATION_NAMES = {
     'Marthas': "Martha's Express",
     "McCormick's": "McCormick's at Moakley House",
     'North Star Marketplace': 'North Star Dining Room',
-    'Olin Libe Cafe': 'Amit Bhatia Libe Café',
+    'Olin Libe Cafe': 'Libe Café',
     'RPME': 'Robert Purcell Marketplace Eatery',
     'Risley': 'Risley Dining Room',
     'Rose House': 'Rose House Dining Room',

--- a/src/data.py
+++ b/src/data.py
@@ -68,10 +68,11 @@ def merge_hours(eateries):
       base_event = operating_hour.events[0]
       for event in operating_hour.events[1:]:  # iterate over copy of list so we can safely remove
         if (event.start_time == base_event.end_time and
-            event.menu and
             base_event.menu and
-            event.menu[0].equals(base_event.menu[0])):
+            (not event.menu or
+            event.menu[0].equals(base_event.menu[0]))):
           base_event.end_time = event.end_time
           operating_hour.events.remove(event)
           print('merged events for {} on {}'.format(eatery.name, operating_hour.date))
-        base_event = event
+        else:
+          base_event = event

--- a/src/eatery/common_eatery.py
+++ b/src/eatery/common_eatery.py
@@ -154,7 +154,7 @@ def parse_food_items(item_list):
     )
   return new_food_items
 
-def resolve_id(eatery, collegetown=False, ):
+def resolve_id(eatery, collegetown=False):
   """Returns a new id (int) for an external eatery
   If the eatery does not have a provided id, we need to create one.
   Since all provided eatery ID values are positive, we decrement starting at 0.
@@ -162,10 +162,10 @@ def resolve_id(eatery, collegetown=False, ):
   if not collegetown and 'id' in eatery:
     return eatery['id']
   elif eatery['name'] in static_eateries:
-    return static_eateries['id']
-
-  static_eateries[eatery['name']] = -1 * len(static_eateries)
-  return -1 * len(static_eateries)
+    return static_eateries[eatery['name']]
+  new_id = -1 * len(static_eateries)
+  static_eateries[eatery['name']] = new_id
+  return new_id
 
 def get_image_url(slug):
   """Generates a URL for an image.

--- a/src/schema.py
+++ b/src/schema.py
@@ -11,6 +11,7 @@ from src.constants import (
     CORNELL_INSTITUTION_ID,
     GET_URL,
     IGNORE_LOCATIONS,
+    LOCATION_NAMES,
     SWIPE_PLANS,
 )
 from src.types import (
@@ -136,17 +137,17 @@ class Query(ObjectType):
 
     account_info['history'] = []
 
-    for t in transactions:
-      if ACCOUNT_NAMES['brbs'] not in t['accountName'] or t['locationName'] in IGNORE_LOCATIONS:
+    for txn in transactions:
+      if ACCOUNT_NAMES['brbs'] not in txn['accountName'] or txn['locationName'] in IGNORE_LOCATIONS:
         continue
-      dt_utc = parser.parse(t['actualDate']).astimezone(pytz.timezone('UTC'))
-      dt_est = dt_utc.astimezone(pytz.timezone('US/Eastern'))
+      txn_timestamp = parser.parse(txn['actualDate']).astimezone(pytz.timezone('US/Eastern'))
+      location = txn['locationName'].rsplit(' ', 1)[0]
+      # removes the register numbers at the end of the string by taking the substring up until
+      # the last space (right before the number)
       new_transaction = {
-          'amount': t['amount'],
-          'name': t['locationName'][:t['locationName'].rfind(' ')],
-          # removes the register numbers at the end of the string by taking the substring up until
-          # the last space (right before the number)
-          'timestamp': dt_est.strftime("%D at %I:%M %p")
+          'amount': txn['amount'],
+          'name': LOCATION_NAMES.get(location, location),
+          'timestamp': txn_timestamp.strftime("%A, %b %d at %I:%M %p")
       }
       account_info['history'].append(TransactionType(**new_transaction))
 

--- a/start_server.sh
+++ b/start_server.sh
@@ -1,1 +1,1 @@
-gunicorn -w 4 -t 60 -b 0.0.0.0:5000 app:app
+gunicorn -w 4 -t 60 --graceful_timeout 60 -b 0.0.0.0:5000 app:app


### PR DESCRIPTION
Addresses event merging for events with empty menus, the GET location names and reformatting of timestamps, and a bug caused by updating static eateries in the resolve_id method.  Hopefully this will fix our yelp issues, one can only look to the debug gods on this one. 