### PR TITLE
Fix gunicorn config

### DIFF
--- a/start_server.sh
+++ b/start_server.sh
@@ -1,1 +1,1 @@
-gunicorn -w 4 -t 60 --graceful_timeout 60 -b 0.0.0.0:5000 app:app
+gunicorn -w 4 -t 300 --graceful-timeout 60 -b 0.0.0.0:5000 app:app


### PR DESCRIPTION
Increasing the timeout to 300 fixes the issue where workers regularly timeout