### PR TITLE
Increase gunicorn timeout

### DIFF
--- a/start_server.sh
+++ b/start_server.sh
@@ -1,1 +1,1 @@
-gunicorn -w 4 -t 300 --graceful-timeout 60 -b 0.0.0.0:5000 app:app
+gunicorn -w 4 -t 480 --graceful-timeout 60 -b 0.0.0.0:5000 app:app


### PR DESCRIPTION
Parsing the swipe data takes a while so when the server starts the workers would timeout before it could finish so the workers would reboot and retry. Increasing the timeout allows sufficient time for the workers to finish parsing the swipe data (tested locally and is currently running in prod)