### PR TITLE
Fix swipe data parsing error

### DIFF
--- a/src/eatery/static_eatery.py
+++ b/src/eatery/static_eatery.py
@@ -87,14 +87,14 @@ def parse_static_op_hours(hours_list, dining_items, dates_closed):
   new_operating_hours = []
   for i in range(NUM_DAYS_STORED_IN_DB):
     new_date = today + timedelta(days=i)
-    for dates in dates_closed:
-      if '-' not in dates:
-        closed_date = datetime.strptime(dates, '%m/%d/%y').date()
-        if new_date == closed_date:
-          break
-      else:
+    for dates in dates_closed:  # check if dates_closed contains new_date
+      if '-' in dates:  # indicates this string is a date range of form "mm/dd/yy-mm/dd/yy"
         start_date, end_date = string_to_date_range(dates)
         if start_date <= new_date <= end_date:
+          break
+      else:  # date string is a singular date
+        closed_date = datetime.strptime(dates, '%m/%d/%y').date()
+        if new_date == closed_date:
           break
     else:
       # new_date is not present in dates_closed, we can add this date to the db

--- a/src/swipes.py
+++ b/src/swipes.py
@@ -69,7 +69,10 @@ def parse_to_csv(file_name='data.csv'):
           continue
 
         obj = json.loads(line)
-        timestamp_str = obj['TIMESTAMP']
+        timestamp_str = obj.get('TIMESTAMP', None)
+        if not timestamp_str:
+          # we have received {"msg":"Unauthorized"} as a log twice instead of real data
+          continue
         if timestamp_str == 'Invalid date' or not obj['UNITS']:  # obj['UNITS'] contains locations
           continue
 
@@ -131,7 +134,7 @@ def parse_to_csv(file_name='data.csv'):
                   'session_type': session_type,
                   'location': location,
                   'start_time': start_time,
-                  'swipes': place['CROWD_COUNT'],
+                  'swipes': place.get('CROWD_COUNT', 0),
                   'weekday': weekday,
                   'multiplier': WAIT_TIME_CONVERSION[LOCATION_NAMES[location]['type']],
               }, index=[0]


### PR DESCRIPTION
Encountered a bug where data.log (stores the queries from cornell dining
requests every 5 minutes) contains two logs of {"msg": "Unauthorized"}
which created a key error when we tried to access 'TIMESTAMP' from the
log. This exception was not caught and prevented further updating of
our csv files. This bug may also be responsible for inconsistent ctown
data. We fix the issue by checking the 'TIMESTAMP' is a valid key in the
log.