### PR TITLE
Error catching for get swipes

### DIFF
--- a/src/schema.py
+++ b/src/schema.py
@@ -116,8 +116,11 @@ class Query(ObjectType):
         account_info['swipes'] = str(acct['balance'])
 
     # Check if the meal plan has more than 50 swipes, this is larger than the largest plan.
-    if (int(account_info['swipes']) > 50):
-      account_info['swipes'] = 'Unlimited'
+    try:
+      if (int(account_info['swipes']) > 50):
+        account_info['swipes'] = 'Unlimited'
+    except:
+      account_info['swipes'] = 'None'
 
     # Query 3: Get list of transactions
     transactions = requests.post(

--- a/src/schema.py
+++ b/src/schema.py
@@ -115,12 +115,11 @@ class Query(ObjectType):
       elif any(meal_swipe_name in acct['accountDisplayName'] for meal_swipe_name in SWIPE_PLANS):
         account_info['swipes'] = str(acct['balance'])
 
-    # Check if the meal plan has more than 50 swipes, this is larger than the largest plan.
-    try:
+    # Check if the balance provided by Cornell Dining is a regular digit
+    if (account_info['swipes'].isdigit()):
+      # Check if the meal plan has more than 50 swipes, this is larger than the largest plan.
       if (int(account_info['swipes']) > 50):
         account_info['swipes'] = 'Unlimited'
-    except:
-      account_info['swipes'] = 'None'
 
     # Query 3: Get list of transactions
     transactions = requests.post(


### PR DESCRIPTION
Solves the issue found in server logs. 

```
An error occurred while resolving field Query.accountInfo
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/graphql/execution/executor.py", line 447, in resolve_or_error
    return executor.execute(resolve_fn, source, info, **args)
  File "/usr/local/lib/python3.6/site-packages/graphql/execution/executors/sync.py", line 16, in execute
    return fn(*args, **kwargs)
  File "/usr/src/app/src/schema.py", line 118, in resolve_account_info
    if (int(account_info['swipes']) > 50):
ValueError: invalid literal for int() with base 10: 'None'
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/graphql/execution/executor.py", line 447, in resolve_or_error
    return executor.execute(resolve_fn, source, info, **args)
  File "/usr/local/lib/python3.6/site-packages/graphql/execution/executors/sync.py", line 16, in execute
    return fn(*args, **kwargs)
  File "/usr/src/app/src/schema.py", line 118, in resolve_account_info
    if (int(account_info['swipes']) > 50):
graphql.error.located_error.GraphQLLocatedError: invalid literal for int() with base 10: 'None'
```

I'm not sure which meal plan returns `"None"` swipes and when this happens, but this should catch it.