### PR TITLE
Preload data before starting gunicorn workers

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,7 +7,6 @@ from src.schema import Query
 
 app = Flask(__name__)
 schema = Schema(query=Query)
-start_update()
 
 app.add_url_rule(
     '/',

--- a/gunicorn.py
+++ b/gunicorn.py
@@ -1,0 +1,10 @@
+from src.data import start_update
+
+def on_starting(server):
+    start_update()
+
+workers = 4
+timeout = 480
+graceful_timeout = 60
+bind = '0.0.0.0:5000'
+preload_app = True

--- a/start_server.sh
+++ b/start_server.sh
@@ -1,1 +1,1 @@
-gunicorn -w 4 -t 480 --graceful-timeout 60 -b 0.0.0.0:5000 app:app
+gunicorn -c gunicorn.py app:app


### PR DESCRIPTION
After doing some research, I discovered you can do stuff before gunicorn starts its workers!
- Before starting the workers, you can make gunicorn run a method called `on_starting`
- I placed the `start_update()` method call in here which handles swipe data, campus eateries, and collegetown eateries
- That way this data update process doesn't run separately by each worker during startup but only once in the beginning
- Previously a lot of gunicorn workers would timeout and do this process over again making startup time infinite
- I also moved the gunicorn configurations into the `gunicorn.py` file

You can see here that the data fetching occurs before the workers start
![Screen Shot 2019-09-18 at 12 23 47 AM](https://user-images.githubusercontent.com/22579863/65111931-c472be80-d9ab-11e9-8896-b85ebe775f24.png)

![Screen Shot 2019-09-18 at 12 24 40 AM](https://user-images.githubusercontent.com/22579863/65111933-c5a3eb80-d9ab-11e9-9d93-755f8a65ef7a.png)

This is currently deployed on prod since the previous deployed image failed to startup when enabling swipe data. This is a temporary solution until we can get the database up.