### PR TITLE
Skip lines in swipe logs that aren't formatted correctly

### DIFF
--- a/src/swipes.py
+++ b/src/swipes.py
@@ -70,7 +70,10 @@ def parse_to_csv(file_name="data.csv"):
                 if not line:
                     continue
 
-                obj = json.loads(line)
+                try:
+                    obj = json.loads(line)
+                except:
+                    continue
                 timestamp_str = obj.get("TIMESTAMP", None)
                 if not timestamp_str:
                     # we have received {"msg":"Unauthorized"} as a log twice instead of real data


### PR DESCRIPTION
Swipe data wasn't working due to a parse error and upon looking at the data.log file I found this in the logs so I added some error handling to skip lines like this

<img width="1440" alt="Screen Shot 2019-09-25 at 12 47 16 AM" src="https://user-images.githubusercontent.com/22579863/65570191-445dd300-df2e-11e9-85d0-3e0a2b59ddf6.png">

Tested in locally by downloading the swipe data on the server