### PR TITLE
Parse from db to graphQL

### DIFF
--- a/gunicorn.py
+++ b/gunicorn.py
@@ -1,8 +1,8 @@
-from src.data import start_update
+from src.db import start_update
 
 
 def on_starting(server):
-    start_update()
+    start_update(True, True)
 
 
 workers = 4

--- a/src/constants.py
+++ b/src/constants.py
@@ -8,7 +8,7 @@ BRB_ONLY = "brb_only"
 CORNELL_DINING_URL = "https://now.dining.cornell.edu/api/1.0/dining/eateries.json"
 CORNELL_INSTITUTION_ID = "73116ae4-22ad-4c71-8ffd-11ba015407b1"
 DINING_HALL = "dining_hall"
-EATERY_DATA_PATH = "../eatery-data/"
+EATERY_DATA_PATH = "./eatery-data/"
 GET_LOCATIONS = {
     "Attrium Cafe": "Atrium Café",
     "Bear Necessities Grill & C-Store": "Bear Necessities",
@@ -76,6 +76,7 @@ SCHOOL_BREAKS = {
     "finals_spring": "5/6/20-5/16/20",
     "summer": "5/17/20-8/27/20",
 }
+SQLITE_MAX_VARIABLE_NUMBER = 999
 STATIC_SOURCES_URL = GIT_CONTENT_URL + "/eatery-backend/master/static_sources/"
 STATIC_CTOWN_HOURS_URL = STATIC_SOURCES_URL + "externalHours.json"
 STATIC_EATERIES_URL = STATIC_SOURCES_URL + "externalEateries.json"

--- a/src/database/CampusEateryHour.py
+++ b/src/database/CampusEateryHour.py
@@ -10,7 +10,7 @@ class CampusEateryHour(Base):
 
     id = Column(Integer, nullable=False, primary_key=True)
     date = Column(String, nullable=False)
-    event_description = Column(String, nullable=False)
-    event_summary = Column(String, nullable=False)
-    end_time = Column(String, nullable=False)
-    start_time = Column(String, nullable=False)
+    event_description = Column(String, nullable=True)
+    event_summary = Column(String, nullable=True)
+    end_time = Column(String, nullable=True)
+    start_time = Column(String, nullable=True)

--- a/src/database/MenuCategory.py
+++ b/src/database/MenuCategory.py
@@ -5,8 +5,12 @@ from .config import Base
 
 class MenuCategory(Base):
     @declared_attr
-    def event_id(cls):
+    def event_id(cls):  # Null for dining items because they don't belong to a specific event
         return Column(Integer, ForeignKey("campusEateryHours.id"), nullable=True)
+
+    @declared_attr
+    def eatery_id(cls):
+        return Column(Integer, ForeignKey("campusEateryHours.eatery_id"), nullable=False)
 
     __tablename__ = "menuCategories"
     id = Column(Integer, nullable=False, primary_key=True)

--- a/src/db.py
+++ b/src/db.py
@@ -20,10 +20,10 @@ from .eatery_db import (
     parse_to_csv,
 )
 
+conn = Engine.connect()
+
 
 def get_campus_eateries(data_json, refresh=False):
-    campus_eateries = CampusEatery.query.all()
-
     if refresh:
         Base.metadata.drop_all(bind=Engine)
         Base.metadata.create_all(bind=Engine)
@@ -31,6 +31,8 @@ def get_campus_eateries(data_json, refresh=False):
         campus_eateries = parse_campus_eateries(data_json)
         Session.add_all(campus_eateries)
         Session.commit()
+    else:
+        campus_eateries = CampusEatery.query.all()
 
     return campus_eateries
 

--- a/src/db.py
+++ b/src/db.py
@@ -3,7 +3,7 @@ import requests
 
 from .collegetown import collegetown_search
 from .constants import CORNELL_DINING_URL, STATIC_EATERIES_URL, STATIC_EATERY_SLUGS, STATIC_EXPANDED_ITEMS_URL
-from .database import CampusEatery, CollegetownEatery, CollegetownEateryHour, Base, Engine, Session, SwipeData
+from .database import Base, CampusEatery, CollegetownEatery, CollegetownEateryHour, Engine, Session, SwipeData
 from .eatery_db import (
     export_data,
     parse_campus_eateries,
@@ -74,13 +74,17 @@ def start_update(refresh_campus=False, recalculate_swipe=False):
 
             # if this is not a refresh, then static eateries are part of campus_eateries
             if eatery.slug not in STATIC_EATERY_SLUGS:
-                hours_and_menus = parse_campus_hours(campus_json, eatery)
+                hours_and_menus, dining_items = parse_campus_hours(campus_json, eatery)
                 eatery_hours = (x[0] for x in hours_and_menus)
                 Session.add_all(eatery_hours)
                 Session.commit()
 
+                if dining_items:
+                    hours_and_menus.append((None, dining_items))
+
                 for eatery_hour, menu_json in hours_and_menus:
-                    categories_and_items = parse_menu_categories(menu_json, eatery_hour)
+                    categories_and_items = parse_menu_categories(menu_json, eatery_hour, eatery.id)
+
                     eatery_categories = (x[0] for x in categories_and_items)
                     Session.add_all(eatery_categories)
                     Session.commit()
@@ -109,7 +113,7 @@ def start_update(refresh_campus=False, recalculate_swipe=False):
                 Session.commit()
 
                 for eatery_hour, menu_json in hours_and_menus:
-                    categories_and_items = parse_menu_categories(menu_json, eatery_hour)
+                    categories_and_items = parse_menu_categories(menu_json, eatery_hour, eatery.id)
                     eatery_categories = (x[0] for x in categories_and_items)
                     Session.add_all(eatery_categories)
                     Session.commit()

--- a/src/eatery_db/campus_eatery.py
+++ b/src/eatery_db/campus_eatery.py
@@ -50,47 +50,57 @@ def parse_campus_eateries(data_json):
 def parse_campus_hours(data_json, eatery_model):
     """Parses a Cornell Dining json dictionary.
 
-    Returns a list of tuples of CampusEateryHour objects for a corresponding CampusEatery object and their unparsed
-    menu.
+    Returns 1) a list of tuples of CampusEateryHour objects for a corresponding CampusEatery object and their unparsed
+    menu 2) an array of the items an eatery serves.
 
     Args:
         data_json (dict): a valid dictionary from the Cornell Dining json
         eatery_model (CampusEatery): the CampusEatery object to which to link the hours.
     """
     eatery_hours_and_menus = []
+    dining_items = []
 
     for eatery in data_json["data"]["eateries"]:
         eatery_slug = eatery.get("slug", "")
-        dining_items = get_trillium_menu() if eatery_slug == TRILLIUM_SLUG else parse_dining_items(eatery)
 
         if eatery_model.slug == eatery_slug:
+            dining_items = get_trillium_menu() if eatery_slug == TRILLIUM_SLUG else parse_dining_items(eatery)
             hours_list = eatery["operatingHours"]
 
             for hours in hours_list:
                 new_date = hours.get("date", "")
                 hours_events = hours["events"]
 
-                for event in hours_events:
-                    start, end = format_time(event.get("start", ""), event.get("end", ""), new_date)
+                if hours_events:
+                    for event in hours_events:
+                        start, end = format_time(event.get("start", ""), event.get("end", ""), new_date)
 
+                        eatery_hour = CampusEateryHour(
+                            eatery_id=eatery_model.id,
+                            date=new_date,
+                            event_description=event.get("descr", ""),
+                            event_summary=event.get("calSummary", ""),
+                            end_time=end,
+                            start_time=start,
+                        )
+
+                        eatery_hours_and_menus.append((eatery_hour, event.get("menu", [])))
+
+                else:
                     eatery_hour = CampusEateryHour(
                         eatery_id=eatery_model.id,
                         date=new_date,
-                        event_description=event.get("descr", ""),
-                        event_summary=event.get("calSummary", ""),
-                        end_time=end,
-                        start_time=start,
+                        event_description=None,
+                        event_summary=None,
+                        end_time=None,
+                        start_time=None,
                     )
+                    eatery_hours_and_menus.append((eatery_hour, []))
 
-                    if not event["menu"] and dining_items:
-                        event["menu"] = dining_items
-
-                    eatery_hours_and_menus.append((eatery_hour, event.get("menu", [])))
-
-    return eatery_hours_and_menus
+    return eatery_hours_and_menus, dining_items
 
 
-def parse_menu_categories(menu_json, hour_model):
+def parse_menu_categories(menu_json, hour_model, eatery_id):
     """Parses the menu portion of the Cornell Dining json dictionary.
 
     Returns a tuple of a MenuCategory object linked to the provided CampusHours object and the unparsed items of that
@@ -100,13 +110,16 @@ def parse_menu_categories(menu_json, hour_model):
         menu_json (dict): a valid dictionary from the Cornell Dining json
         hours_model (CampusHours): the CampusHours object to which to link the menu.
     """
+    if not hour_model:
+        return [(MenuCategory(event_id=None, eatery_id=eatery_id, category=""), menu_json)]
+
     categories_and_items = []
     for menu in menu_json:
         if menu.get("category"):
-            new_category = MenuCategory(event_id=hour_model.id, category=menu.get("category"))
+            new_category = MenuCategory(event_id=hour_model.id, eatery_id=eatery_id, category=menu.get("category"))
             categories_and_items.append((new_category, menu.get("items", [])))
         elif menu.get("item"):
-            return [(MenuCategory(event_id=hour_model.id, category="General"), menu_json)]
+            return [(MenuCategory(event_id=hour_model.id, eatery_id=eatery_id, category="General"), menu_json)]
     return categories_and_items
 
 
@@ -221,8 +234,8 @@ def parse_static_op_hours(data_json, eatery_model):
                                 CampusEateryHour(
                                     eatery_id=eatery_model.id,
                                     date=new_date.isoformat(),
-                                    event_description=event.get("calSummary", ""),
-                                    event_summary=event.get("descr", ""),
+                                    event_description=event.get("descr", ""),
+                                    event_summary=event.get("calSummary", ""),
                                     end_time=end,
                                     start_time=start,
                                 ),
@@ -278,16 +291,16 @@ def parse_payments(methods):
 def parse_dining_items(eatery):
     """Parses the dining items of an eatery.
 
-    Returns a list that holds a dictionary for the items an eatery serves and a flag for healthy
+    Returns an array of the items an eatery serves and a flag for healthy
     options. Exclusive to non-dining hall eateries.
 
     Args:
         eatery (dict): A valid json dictionary from Cornell Dining that contains eatery information
     """
-    dining_items = {"items": []}
+    dining_items = []
     for item in eatery["diningItems"]:
-        dining_items["items"].append({"healthy": item.get("healthy", False), "item": item.get("item", "")})
-    return [dining_items]
+        dining_items.append({"healthy": item.get("healthy", False), "item": item.get("item", "")})
+    return dining_items
 
 
 def get_trillium_menu():

--- a/src/eatery_db/collegetown_eatery.py
+++ b/src/eatery_db/collegetown_eatery.py
@@ -77,7 +77,7 @@ def parse_collegetown_hours(data_json, eatery_model):
                         event.get("start", ""),
                         event.get("end", ""),
                         new_date.isoformat(),
-                        hr24=True,
+                        is_24_hour_time=True,
                         overnight=event.get("is_overnight", False),
                     )
                     new_operating_hours.append(

--- a/src/eatery_db/swipes.py
+++ b/src/eatery_db/swipes.py
@@ -168,7 +168,7 @@ def parse_to_csv(file_name="data.csv"):
     except Exception as e:
         print("Failed at parse_to_csv")
         print("Data update failed:", e)
-        return "../eatery-data/timeblock-averages.csv"
+        return "./eatery-data/timeblock-averages.csv"
         traceback.print_exc()
 
 

--- a/src/gql_parser/__init__.py
+++ b/src/gql_parser/__init__.py
@@ -1,0 +1,4 @@
+# flake8: noqa
+
+from .campus_eatery import get_campus_eateries
+from .collegetown_eatery import get_collegetown_eateries

--- a/src/gql_parser/campus_eatery.py
+++ b/src/gql_parser/campus_eatery.py
@@ -1,0 +1,328 @@
+from ..constants import SQLITE_MAX_VARIABLE_NUMBER
+from ..db import conn
+from ..database import (
+    CampusEatery,
+    CampusEateryHour,
+    ExpandedMenuChoice,
+    ExpandedMenuItem,
+    ExpandedMenuStation,
+    MenuCategory,
+    MenuItem,
+    SwipeData,
+)
+from ..gql_parser.common_eatery import parse_coordinates, parse_payment_methods, parse_payment_methods_enum
+from ..gql_types import (
+    CampusAreaType,
+    CampusEateryType,
+    EventType,
+    FoodCategoryType,
+    FoodItemType,
+    FoodStationType,
+    DescriptiveFoodItemOptionType,
+    DescriptiveFoodItemType,
+    DescriptiveFoodStationType,
+    OperatingHoursType,
+    SwipeDataType,
+)
+
+
+def get_campus_eateries(eatery_id):
+    """Queries db to fetch information about a specific or all campus eateries.
+
+    Returns a list of CampusEateryType objects.
+    """
+    if eatery_id is not None:
+        query = CampusEatery.query.filter_by(id=eatery_id)
+    else:
+        query = CampusEatery.query
+
+    result = conn.execute(query.statement).fetchall()
+    columns = CampusEatery.__table__.columns.keys()
+
+    populated_result = []
+    for data in result:
+        mapped_eatery = {}
+        for i, column_name in enumerate(columns):
+            mapped_eatery[column_name] = data[i]
+        populated_eatery = parse_campus_eatery(mapped_eatery)
+        populated_result.append(populated_eatery)
+
+    return populated_result
+
+
+def parse_campus_eatery(eatery):
+    """Parses eatery data from db and populates to an object.
+
+    Returns a new CampusEateryType.
+    """
+
+    new_eatery = CampusEateryType(
+        about=eatery.get("about", ""),
+        campus_area=parse_campus_area(eatery),
+        coordinates=parse_coordinates(eatery),
+        eatery_type=eatery.get("eatery_type", ""),
+        expanded_menu=parse_expanded_menu(eatery),
+        id=eatery.get("id"),
+        image_url=eatery.get("image_url"),
+        location=eatery.get("location", ""),
+        name=eatery.get("name", ""),
+        name_short=eatery.get("name_short", ""),
+        operating_hours=parse_operating_hours(eatery),
+        payment_methods=parse_payment_methods(eatery),
+        payment_methods_enums=parse_payment_methods_enum(eatery),
+        phone=eatery.get("phone", "N/A"),
+        slug=eatery.get("slug", ""),
+        swipe_data=parse_swipe_data(eatery),
+    )
+    return new_eatery
+
+
+def parse_campus_area(eatery):
+    """Parses the common name location of an eatery.
+
+    Returns a new CampusAreaType that contains a description of an eatery.
+    """
+    campus_area = eatery.get("campus_area_desc", "")
+
+    return CampusAreaType(description_short=campus_area)
+
+
+def parse_expanded_menu(eatery):
+    """Queries db for expanded menu stations, items, and chocies that are relevant to the specific eatery, then parses
+    the information into appropriate data format.
+
+    Returns a list FoodCategoryType objects.
+    """
+    # query for all menu STATIONs that will be needed to populate expanded menu
+    query_stations = ExpandedMenuStation.query.filter_by(campus_eatery_id=eatery.get("id"))
+    result_stations = conn.execute(query_stations.statement).fetchall()
+    column_stations = ExpandedMenuStation.__table__.columns.keys()
+
+    menu_to_station = {}
+    station_ids = []
+    for station in result_stations:
+        mapped_station = {}
+        for i, column_name in enumerate(column_stations):
+            mapped_station[column_name] = station[i]
+
+        menu_category = mapped_station["menu_category"]
+        if menu_category in menu_to_station:
+            menu_to_station[menu_category].append(mapped_station)
+        else:
+            menu_to_station[menu_category] = [mapped_station]
+        station_ids.append(mapped_station["id"])
+
+    # query for all menu ITEMs that will be needed to populate expanded menu
+    result_items = []
+    while station_ids:
+        partial_query = ExpandedMenuItem.query.filter(
+            ExpandedMenuItem.station_category_id.in_(station_ids[:SQLITE_MAX_VARIABLE_NUMBER])
+        )
+        partial_result = conn.execute(partial_query.statement).fetchall()
+        result_items += partial_result
+        station_ids = station_ids[SQLITE_MAX_VARIABLE_NUMBER:]
+    column_items = ExpandedMenuItem.__table__.columns.keys()
+
+    station_to_item = {}
+    item_ids = []
+    for item in result_items:
+        mapped_item = {}
+        for i, column_name in enumerate(column_items):
+            mapped_item[column_name] = item[i]
+
+        station_category = mapped_item["station_category_id"]
+        if station_category in station_to_item:
+            station_to_item[station_category].append(mapped_item)
+        else:
+            station_to_item[station_category] = [mapped_item]
+        item_ids.append(mapped_item["id"])
+
+    # query for all menu ITEMs that will be needed to populate expanded menu
+    result_choices = []
+    while item_ids:
+        partial_query = ExpandedMenuChoice.query.filter(
+            ExpandedMenuChoice.menu_item_id.in_(item_ids[:SQLITE_MAX_VARIABLE_NUMBER])
+        )
+        partial_result = conn.execute(partial_query.statement).fetchall()
+        result_choices += partial_result
+        item_ids = item_ids[SQLITE_MAX_VARIABLE_NUMBER:]
+    column_choices = ExpandedMenuChoice.__table__.columns.keys()
+
+    item_to_choice = {}
+    for choice in result_choices:
+        mapped_choice = {}
+        for i, column_name in enumerate(column_choices):
+            mapped_choice[column_name] = choice[i]
+
+        menu_item = mapped_choice["menu_item_id"]
+        if menu_item in item_to_choice:
+            item_to_choice[menu_item].append(mapped_choice)
+        else:
+            item_to_choice[menu_item] = [mapped_choice]
+
+    # Put together stations, items, and choices
+    populated_result = []
+    for menu_category in menu_to_station:
+        stations_arr = menu_to_station[menu_category]
+        station_objs_arr = []
+
+        for station in stations_arr:
+            items_arr = station_to_item.get(station["id"], [])
+            item_objs_arr = []
+
+            for item in items_arr:
+                choices_arr = item_to_choice.get(item["id"], [])
+                choice_objs_arr = []
+
+                for choice in choices_arr:
+                    options_arr = choice["options"].split(", ")
+                    options = map(lambda x: x[1:-1], options_arr)
+                    choice_obj = DescriptiveFoodItemOptionType(label=choice["label"], options=options)
+                    choice_objs_arr.append(choice_obj)
+
+                item_obj = DescriptiveFoodItemType(
+                    item=item["item"], healthy=item["healthy"], price=item["price"], choices=choice_objs_arr
+                )
+                item_objs_arr.append(item_obj)
+
+            station_obj = DescriptiveFoodStationType(category=station["station_category"], items=item_objs_arr)
+            station_objs_arr.append(station_obj)
+
+        result_obj = FoodCategoryType(category=menu_category, stations=station_objs_arr)
+        populated_result.append(result_obj)
+
+    return populated_result
+
+
+def parse_operating_hours(eatery):
+    """Queries db for operating hours, menu categories, and menu items that are relevant to the specific eatery,
+    then parses the information into appropriate data format.
+
+    Returns a list OperatingHoursType objects.
+    """
+    # query for all OPERATING_HOURs that will be needed to populate operating hours
+    query_hours = CampusEateryHour.query.filter_by(eatery_id=eatery.get("id"))
+    result_hours = conn.execute(query_hours.statement).fetchall()
+    column_hours = CampusEateryHour.__table__.columns.keys()
+
+    date_to_event = {}
+    event_ids = []
+    for hour in result_hours:
+        mapped_hour = {}
+        for i, column_name in enumerate(column_hours):
+            mapped_hour[column_name] = hour[i]
+
+        date = mapped_hour["date"]
+        if date in date_to_event:
+            date_to_event[date].append(mapped_hour)
+        else:
+            date_to_event[date] = [mapped_hour]
+        event_ids.append(mapped_hour["id"])
+
+    # query for all MENU_CATEGORY that will be needed to populate operating hours
+    result_categories = []
+    while event_ids:
+        partial_query = MenuCategory.query.filter(MenuCategory.event_id.in_(event_ids[:SQLITE_MAX_VARIABLE_NUMBER]))
+        partial_result = conn.execute(partial_query.statement).fetchall()
+        result_categories += partial_result
+        event_ids = event_ids[SQLITE_MAX_VARIABLE_NUMBER:]
+    column_categories = MenuCategory.__table__.columns.keys()
+
+    event_to_category = {}
+    category_ids = []
+    for category in result_categories:
+        mapped_category = {}
+        for i, column_name in enumerate(column_categories):
+            mapped_category[column_name] = category[i]
+
+        event = category["event_id"]
+        if event in event_to_category:
+            event_to_category[event].append(mapped_category)
+        else:
+            event_to_category[event] = [mapped_category]
+        category_ids.append(mapped_category["id"])
+
+    # query for all MENU_ITEMs that will be needed to populate operating hours
+    result_items = []
+    while category_ids:
+        partial_query = MenuItem.query.filter(MenuItem.category_id.in_(category_ids[:SQLITE_MAX_VARIABLE_NUMBER]))
+        partial_result = conn.execute(partial_query.statement).fetchall()
+        result_items += partial_result
+        category_ids = category_ids[SQLITE_MAX_VARIABLE_NUMBER:]
+    column_items = MenuItem.__table__.columns.keys()
+
+    category_to_item = {}
+    for item in result_items:
+        mapped_item = {}
+        for i, column_name in enumerate(column_items):
+            mapped_item[column_name] = item[i]
+
+        category = item["category_id"]
+        if category in category_to_item:
+            category_to_item[category].append(mapped_item)
+        else:
+            category_to_item[category] = [mapped_item]
+
+    # Put together hours, categories, and items
+    populated_result = []
+    for date in date_to_event:
+        events_arr = date_to_event[date]
+        events_objs_arr = []
+
+        for event in events_arr:
+            categories_arr = event_to_category.get(event["id"], [])
+            categories_objs_arr = []
+
+            for category in categories_arr:
+                items_arr = category_to_item.get(category["id"], [])
+                items_objs_arr = []
+
+                for item in items_arr:
+                    item_obj = FoodItemType(item=item["item"], healthy=item["healthy"])
+                    items_objs_arr.append(item_obj)
+
+                category_obj = FoodStationType(category=category["category"], items=items_objs_arr)
+                categories_objs_arr.append(category_obj)
+
+            events_obj = EventType(
+                cal_summary=event["event_summary"],
+                description=event["event_description"],
+                end_time=event["end_time"],
+                menu=categories_objs_arr,
+                start_time=event["start_time"],
+            )
+            events_objs_arr.append(events_obj)
+
+        result_obj = OperatingHoursType(date=date, events=events_objs_arr)
+        populated_result.append(result_obj)
+
+    return populated_result
+
+
+def parse_swipe_data(eatery):
+    """Queries db for an eatery's swipe data, then parses the information into appropriate data format.
+
+    Returns a list SwipeDataType objects.
+    """
+
+    query = SwipeData.query.filter_by(eatery_id=eatery.get("id"))
+    result = conn.execute(query.statement).fetchall()
+    columns = SwipeData.__table__.columns.keys()
+
+    populated_result = []
+    for data in result:
+        mapped_swipe_data = {}
+        for i, column_name in enumerate(columns):
+            mapped_swipe_data[column_name] = data[i]
+
+        new_swipe_data = SwipeDataType(
+            end_time=mapped_swipe_data["end_time"],
+            session_type=mapped_swipe_data["session_type"],
+            start_time=mapped_swipe_data["start_time"],
+            swipe_density=mapped_swipe_data["swipe_density"],
+            wait_time_high=mapped_swipe_data["wait_time_high"],
+            wait_time_low=mapped_swipe_data["wait_time_low"],
+        )
+        populated_result.append(new_swipe_data)
+
+    return populated_result

--- a/src/gql_parser/collegetown_eatery.py
+++ b/src/gql_parser/collegetown_eatery.py
@@ -1,0 +1,117 @@
+from ..db import conn
+from ..database import CollegetownEatery, CollegetownEateryHour
+from ..gql_parser.common_eatery import parse_coordinates
+from ..gql_types import (
+    CollegetownEateryType,
+    CollegetownEventType,
+    CollegetownHoursType,
+    PaymentMethodsType,
+    PaymentMethodsEnum,
+    RatingEnum,
+)
+
+
+def get_collegetown_eateries(eatery_id):
+    """Queries db to fetch information about a specific or all collegetown eateries.
+
+    Returns a list of CollegetownEateryType objects.
+    """
+    if eatery_id is not None:
+        query = CollegetownEatery.query.filter_by(id=eatery_id)
+    else:
+        query = CollegetownEatery.query
+
+    result = conn.execute(query.statement).fetchall()
+    columns = CollegetownEatery.__table__.columns.keys()
+
+    populated_result = []
+    for data in result:
+        mapped_eatery = {}
+        for i, column_name in enumerate(columns):
+            mapped_eatery[column_name] = data[i]
+        populated_eatery = parse_collegetown_eateries(mapped_eatery)
+        populated_result.append(populated_eatery)
+
+    return populated_result
+
+
+def parse_collegetown_eateries(eatery):
+    """Parses eatery data from db and populates to an object.
+
+    Returns a new CollegetownEateryType.
+    """
+    new_eatery = CollegetownEateryType(
+        address=eatery.get("address", ""),
+        categories=parse_categories(eatery),
+        coordinates=parse_coordinates(eatery),
+        eatery_type="Collegetown Restaurant",
+        id=eatery.get("id"),
+        image_url=eatery.get("image_url"),
+        name=eatery.get("name", ""),
+        operating_hours=parse_collegetown_hours(eatery),
+        payment_methods=PaymentMethodsType(
+            brbs=False, cash=True, cornell_card=False, credit=True, swipes=False, mobile=False
+        ),
+        payment_methods_enums=[PaymentMethodsEnum.CASH, PaymentMethodsEnum.CREDIT],
+        phone=eatery.get("phone", "N/A"),
+        price=eatery.get("price", ""),
+        rating=eatery.get("rating", "N/A"),
+        rating_enum=parse_rating(eatery),
+        url=eatery.get("url", ""),
+    )
+    return new_eatery
+
+
+def parse_rating(eatery):
+    """Parses the rating of a Collegetown eatery.
+
+    Returns the corresponding rating name according to the RatingEnum.
+    """
+    rating = eatery.get("rating", "N/A")
+    index = int(round(float(rating) * 2))
+    return RatingEnum.get(index)
+
+
+def parse_categories(eatery):
+    """Parses the restaurant category.
+
+    Returns a list of strings.
+    """
+    categories = eatery.get("categories", "").split(",")
+    return list(filter(lambda category: category != "", categories))
+
+
+def parse_collegetown_hours(eatery):
+    """Queries db for operating hours then parses the information into appropriate data format.
+
+    Returns a list CollegetownHoursType objects.
+    """
+    query = CollegetownEateryHour.query.filter_by(eatery_id=eatery.get("id"))
+    result = conn.execute(query.statement).fetchall()
+    columns = CollegetownEateryHour.__table__.columns.keys()
+
+    date_to_event = {}
+    for data in result:
+        mapped_hour = {}
+        for i, column_name in enumerate(columns):
+            mapped_hour[column_name] = data[i]
+
+        hour_event = CollegetownEventType(
+            description=mapped_hour.get("description", ""),
+            end_time=mapped_hour.get("end_time", ""),
+            start_time=mapped_hour.get("start_time", ""),
+        )
+
+        event_date = mapped_hour["date"]
+        if event_date in date_to_event:
+            date_to_event[event_date].append(hour_event)
+        else:
+            date_to_event[event_date] = [hour_event]
+
+    populated_result = []
+    dates_list = list(date_to_event.keys())
+    for date in dates_list:
+        new_hours = CollegetownHoursType(date=date, events=date_to_event.get(date, []))
+        populated_result.append(new_hours)
+
+    return populated_result

--- a/src/gql_parser/collegetown_eatery.py
+++ b/src/gql_parser/collegetown_eatery.py
@@ -77,8 +77,9 @@ def parse_categories(eatery):
 
     Returns a list of strings.
     """
-    categories = eatery.get("categories", "").split(",")
-    return list(filter(lambda category: category != "", categories))
+    categories_arr = eatery.get("categories", "").split(", ")
+    categories = map(lambda x: x[1:-1], categories_arr)
+    return categories
 
 
 def parse_collegetown_hours(eatery):
@@ -97,7 +98,7 @@ def parse_collegetown_hours(eatery):
             mapped_hour[column_name] = data[i]
 
         hour_event = CollegetownEventType(
-            description=mapped_hour.get("description", ""),
+            description=mapped_hour.get("event_description", ""),
             end_time=mapped_hour.get("end_time", ""),
             start_time=mapped_hour.get("start_time", ""),
         )

--- a/src/gql_parser/common_eatery.py
+++ b/src/gql_parser/common_eatery.py
@@ -1,0 +1,59 @@
+from ..gql_types import CoordinatesType, PaymentMethodsEnum, PaymentMethodsType
+
+
+def parse_coordinates(eatery):
+    """Parses the coordinates of an eatery.
+
+    Returns a new CoordinateType that holds the geographic coordinates of an eatery.
+    """
+    latitude = eatery.get("latitude", 0.0)
+    longitude = eatery.get("longitude", 0.0)
+
+    return CoordinatesType(latitude=latitude, longitude=longitude)
+
+
+def parse_payment_methods(eatery):
+    """Returns a PaymentMethodsType according to which payment methods are available at an eatery."""
+
+    payment_method_brbs = eatery.get("payment_method_brbs")
+    payment_method_cash = eatery.get("payment_method_cash")
+    payment_method_cornell_card = eatery.get("payment_method_cornell_card")
+    payment_method_credit = eatery.get("payment_method_credit")
+    payment_method_mobile = eatery.get("payment_method_mobile")
+    payment_method_swipes = eatery.get("payment_method_swipes")
+
+    payment_methods = PaymentMethodsType(
+        brbs=payment_method_brbs,
+        cash=payment_method_cash,
+        cornell_card=payment_method_cornell_card,
+        credit=payment_method_credit,
+        mobile=payment_method_mobile,
+        swipes=payment_method_swipes,
+    )
+    return payment_methods
+
+
+def parse_payment_methods_enum(eatery):
+    """Returns a PaymentMethoddsEnumType according to which payment methods are available at an eatery."""
+
+    payment_method_brbs = eatery.get("payment_method_brbs")
+    payment_method_cash = eatery.get("payment_method_cash")
+    payment_method_cornell_card = eatery.get("payment_method_cornell_card")
+    payment_method_credit = eatery.get("payment_method_credit")
+    payment_method_mobile = eatery.get("payment_method_mobile")
+    payment_method_swipes = eatery.get("payment_method_swipes")
+    payment_methods = []
+
+    if payment_method_brbs:
+        payment_methods.append(PaymentMethodsEnum.BRB)
+    if payment_method_cash:
+        payment_methods.append(PaymentMethodsEnum.CASH)
+    if payment_method_cornell_card:
+        payment_methods.append(PaymentMethodsEnum.CORNELL_CARD)
+    if payment_method_credit:
+        payment_methods.append(PaymentMethodsEnum.CREDIT)
+    if payment_method_mobile:
+        payment_methods.append(PaymentMethodsEnum.MOBILE)
+    if payment_method_swipes:
+        payment_methods.append(PaymentMethodsEnum.SWIPES)
+    return payment_methods

--- a/src/schema.py
+++ b/src/schema.py
@@ -15,6 +15,7 @@ from .constants import (
     SWIPE_PLANS,
 )
 from .gql_types import AccountInfoType, CampusEateryType, CollegetownEateryType, TransactionType
+from .gql_parser import get_campus_eateries, get_collegetown_eateries
 
 
 class Data(object):
@@ -43,13 +44,13 @@ class Query(ObjectType):
         return [eatery] if eatery is not None else []
 
     def resolve_campus_eateries(self, info, eatery_id=None):
-        return Query.get_eateries(Data.campus_eateries, eatery_id)
+        return get_campus_eateries(eatery_id)
 
     def resolve_collegetown_eateries(self, info, eatery_id=None):
-        return Query.get_eateries(Data.collegetown_eateries, eatery_id)
+        return get_collegetown_eateries(eatery_id)
 
     def resolve_eateries(self, info, eatery_id=None):
-        return Query.get_eateries(Data.campus_eateries, eatery_id)
+        return get_campus_eateries(eatery_id)
 
     def resolve_account_info(self, info, session_id=None):
         if session_id is None:

--- a/start_server.sh
+++ b/start_server.sh
@@ -1,1 +1,2 @@
+crontab update_db.txt
 gunicorn -c gunicorn.py app:app

--- a/update_db.sh
+++ b/update_db.sh
@@ -1,0 +1,1 @@
+python -c 'from src.db import start_update; print("Running daily db update"); start_update(True, True)'

--- a/update_db.txt
+++ b/update_db.txt
@@ -1,0 +1,1 @@
+@daily ./update_db.sh


### PR DESCRIPTION
## Overview

Create parsers that handle querying from db file and reformatting data to match GraphQL schema. Also set up daily cron job (NOTE: set as daily for dev server)

## Changes Made

When a query is made to our graphQL backend, we use the data provided in query (such as specific eatery ids) to query the database containing the eatery information. After fetching data, we reformat the data to match GraphQL object types defined in `src/gql_types` directory. 

## Test Coverage

Made example queries to fetch all possible fields in graphQL and made sure no fields cause error.
Made a same query for local server (db) & deployed server (memory) and kind of confirmed that the return the same result - diff compared the two results and most of the differences were caused because 1) ids of eateries are different between db and memory 2) menu differences between when each server refetched data.

<img width="1440" alt="Screen Shot 2019-12-06 at 8 48 11 PM" src="https://user-images.githubusercontent.com/36527727/70367072-ad38c400-186a-11ea-87e6-660b2545db85.png">

<img width="1163" alt="Screen Shot 2019-12-07 at 4 50 42 PM" src="https://user-images.githubusercontent.com/36527727/70381028-c2b4f900-1911-11ea-93b1-2952d845c703.png">
