### PR TITLE
Change path of old swipe parser's data.log file

### DIFF
--- a/src/swipes.py
+++ b/src/swipes.py
@@ -49,7 +49,7 @@ def parse_to_csv(file_name="data.csv"):
     main_csv = "{}{}".format(EATERY_DATA_PATH, file_name)
 
     try:
-        with FileReadBackwards("{}{}".format(EATERY_DATA_PATH, "data.log")) as swipe_data:
+        with FileReadBackwards("eatery-data/data.log") as swipe_data:
             data_list = []
             update_info = {}
 


### PR DESCRIPTION
The old swipe data parser is located in a different directory than the new swipe data parser. This caused an issue with the old parser not loading swipe data as the constant was updated. 

Eventually this file should be removed when databases are the only way we store data, so I just changed the string here rather than add a new constant.