### PR TITLE
Add installation for cron in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.6
 
+RUN apt-get update && apt-get -y install cron
+
 RUN mkdir /usr/src/app
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
## Overview
Since we use crontab to update the DB daily, the Docker image needs this dependency

## Changes Made

Add installation script to Dockerfile

