### PR TITLE
Fix parsing and DB storage of operating hours

### DIFF
--- a/src/database/CollegetownEateryHour.py
+++ b/src/database/CollegetownEateryHour.py
@@ -10,6 +10,6 @@ class CollegetownEateryHour(Base):
 
     id = Column(Integer, nullable=False, primary_key=True)
     date = Column(String, nullable=False)
-    event_description = Column(String, nullable=False)
-    end_time = Column(String, nullable=False)
-    start_time = Column(String, nullable=False)
+    event_description = Column(String, nullable=True)
+    end_time = Column(String, nullable=True)
+    start_time = Column(String, nullable=True)

--- a/src/eatery_db/campus_eatery.py
+++ b/src/eatery_db/campus_eatery.py
@@ -242,6 +242,10 @@ def parse_static_op_hours(data_json, eatery_model):
                                 dining_items,
                             )
                         )
+                    if not new_events:
+                        new_operating_hours.append(
+                            (CampusEateryHour(eatery_id=eatery_model.id, date=new_date.isoformat(),), dining_items)
+                        )
 
             return new_operating_hours
     return []

--- a/src/eatery_db/collegetown_eatery.py
+++ b/src/eatery_db/collegetown_eatery.py
@@ -89,5 +89,9 @@ def parse_collegetown_hours(data_json, eatery_model):
                             start_time=start,
                         )
                     )
+                if not new_events:
+                    new_operating_hours.append(
+                        CollegetownEateryHour(eatery_id=eatery_model.id, date=new_date.isoformat(),)
+                    )
             return new_operating_hours
     return []

--- a/src/gql_parser/collegetown_eatery.py
+++ b/src/gql_parser/collegetown_eatery.py
@@ -97,6 +97,10 @@ def parse_collegetown_hours(eatery):
         for i, column_name in enumerate(columns):
             mapped_hour[column_name] = data[i]
 
+        if not mapped_hour.get("start_time"):
+            date_to_event[mapped_hour["date"]] = []
+            continue
+
         hour_event = CollegetownEventType(
             description=mapped_hour.get("event_description", ""),
             end_time=mapped_hour.get("end_time", ""),


### PR DESCRIPTION
## Overview
Noticed the operating hours on prod and the new DB setup weren't matching up. On the new DB setup if an eatery (collegetown and campus) was closed, there was no entry for that day even though prod had an entry. Also, I noticed that the Lite Dinners with no menus appeared again in the DB setup when in the prod it was just merged with the previous event. It's cause the call to `merge_hours` was never called.

## Changes Made
Made sure we always created entries for eateries even if they were closed for consistency. This required changing fields in `CollegetownEateryHour` to be nullable which actually is now consistent with `CampusEateryHour`. And to make sure the Lite Dinners and Lite Lunches were properly merged, I added the `merge_hours` call and copied the function from `data.py` since that file will be deprecated soon.

## Test Coverage
I diffed the output from production with my local environment and it all matched up. The only issue now is with Mac's hours which will be addressed next.
