### PR TITLE
Add macs to static slugs

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -85,6 +85,7 @@ STATIC_EATERY_SLUGS = [
     "Fork-and-Gavel",
     "Gimme-Coffee",
     "Louies-Lunch",
+    "Macs",
     "Manndible",
     "Terrace",
     "Zeus",


### PR DESCRIPTION
## Overview

Earlier there was an issue where the hours for Mac's weren't showing up. I found that Mac's was a static eatery and that its slug was not included in a necessary constant. Because of this, the hours for Mac's was not parsed correctly


## Changes Made
Added Mac's slug to the list of static slugs in `constants.py`



## Test Coverage
I diffed the Mac's info on the prod server with my local server and found them to match exactly
