### PR TITLE
Fix date to use Eastern timezone

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -1,3 +1,6 @@
+from datetime import datetime
+import pytz
+
 ACCOUNT_NAMES = {
     "brbs": "BRB Big Red Bucks",
     "citybucks": "CB1 City Bucks",
@@ -105,3 +108,7 @@ YELP_LONGITUDE = -76.486043
 YELP_RADIUS = 200  # meters
 YELP_RESTAURANT_LIMIT = 50  # maximum restaurants returned per query (as allowed by yelp)
 YELP_QUERY_DELAY = 0.8  # seconds
+
+
+def get_today():
+    return datetime.now(pytz.timezone("US/Eastern")).date()

--- a/src/eatery/collegetown_eatery.py
+++ b/src/eatery/collegetown_eatery.py
@@ -1,7 +1,7 @@
 import requests
-from datetime import date, timedelta
+from datetime import timedelta
 
-from ..constants import NUM_DAYS_STORED_IN_DB, STATIC_CTOWN_HOURS_URL
+from ..constants import NUM_DAYS_STORED_IN_DB, STATIC_CTOWN_HOURS_URL, get_today
 from ..gql_types import (
     CollegetownEateryType,
     CollegetownEventType,
@@ -69,7 +69,7 @@ def parse_collegetown_hours(eatery):
     new_operating_hours = []
 
     for i in range(NUM_DAYS_STORED_IN_DB):
-        new_date = date.today() + timedelta(days=i)
+        new_date = get_today() + timedelta(days=i)
         new_events = [event for event in hours_list if event["day"] == new_date.weekday()]
         new_operating_hours.append(
             CollegetownHoursType(

--- a/src/eatery/static_eatery.py
+++ b/src/eatery/static_eatery.py
@@ -1,6 +1,6 @@
-from datetime import date, datetime, timedelta
+from datetime import datetime, timedelta
 
-from ..constants import NUM_DAYS_STORED_IN_DB, WEEKDAYS
+from ..constants import NUM_DAYS_STORED_IN_DB, WEEKDAYS, get_today
 from ..gql_types import CampusEateryType, OperatingHoursType
 from .common_eatery import (
     get_image_url,
@@ -79,7 +79,7 @@ def parse_static_op_hours(hours_list, dining_items, dates_closed):
 
     new_operating_hours = []
     for i in range(NUM_DAYS_STORED_IN_DB):
-        new_date = date.today() + timedelta(days=i)
+        new_date = get_today() + timedelta(days=i)
         for dates in dates_closed:  # check if dates_closed contains new_date
             if "-" in dates:  # indicates this string is a date range of form "mm/dd/yy-mm/dd/yy"
                 start_date, end_date = string_to_date_range(dates)

--- a/src/eatery_db/campus_eatery.py
+++ b/src/eatery_db/campus_eatery.py
@@ -1,8 +1,8 @@
-from datetime import date, datetime, timedelta
+from datetime import datetime, timedelta
 import requests
 
 from .common_eatery import format_time, get_image_url, parse_coordinates, string_to_date_range
-from ..constants import NUM_DAYS_STORED_IN_DB, PAY_METHODS, STATIC_MENUS_URL, TRILLIUM_SLUG, WEEKDAYS
+from ..constants import NUM_DAYS_STORED_IN_DB, PAY_METHODS, STATIC_MENUS_URL, TRILLIUM_SLUG, WEEKDAYS, get_today
 from ..database import CampusEatery, CampusEateryHour, MenuCategory, MenuItem
 
 
@@ -190,7 +190,7 @@ def parse_static_op_hours(data_json, eatery_model):
         data_json (dict): a valid dictionary from the Cornell Dining json
         eatery_model (CampusEatery): the CampusEatery object to which to link the hours.
     """
-    today = date.today()
+    today = get_today()
     for eatery in data_json["eateries"]:
         if eatery_model.slug == eatery.get("slug", ""):
             weekdays = {}

--- a/src/eatery_db/collegetown_eatery.py
+++ b/src/eatery_db/collegetown_eatery.py
@@ -1,8 +1,8 @@
-from datetime import date, timedelta
+from datetime import timedelta
 import requests
 
 from .common_eatery import format_time, get_image_url, parse_coordinates
-from ..constants import NUM_DAYS_STORED_IN_DB, STATIC_CTOWN_HOURS_URL
+from ..constants import NUM_DAYS_STORED_IN_DB, STATIC_CTOWN_HOURS_URL, get_today
 from ..database import CollegetownEatery, CollegetownEateryHour
 
 
@@ -53,7 +53,7 @@ def parse_collegetown_hours(data_json, eatery_model):
         data_json (dict): A valid json dictionary from Yelp that contains eatery information
         eater_model (CollegetownEatery): The eatery to which to bind the hours.
     """
-    today = date.today()
+    today = get_today()
     for eatery in data_json:
         if eatery_model.url == eatery.get("url", ""):
             hours_list = eatery.get("hours", [{}])[0].get("open", [])

--- a/src/eatery_db/swipes.py
+++ b/src/eatery_db/swipes.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime, timedelta
+from datetime import datetime, timedelta
 from file_read_backwards import FileReadBackwards
 import json
 import numpy as np
@@ -17,6 +17,7 @@ from ..constants import (
     TRILLIUM,
     WAIT_TIME_CONVERSION,
     WEEKDAYS,
+    get_today,
 )
 
 from ..database import SwipeData
@@ -269,7 +270,7 @@ def export_data(file_path, eatery_models):
 
     try:
         df = pd.read_csv(file_path)
-        today = date.today()
+        today = get_today()
         session_type = sort_session_type(today, breaks)
         swipe_blocks = []
         for location in df["location"].unique():

--- a/src/swipes.py
+++ b/src/swipes.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime, timedelta
+from datetime import datetime, timedelta
 from file_read_backwards import FileReadBackwards
 import json
 import numpy as np
@@ -15,6 +15,7 @@ from .constants import (
     TRILLIUM,
     WAIT_TIME_CONVERSION,
     WEEKDAYS,
+    get_today,
 )
 from .eatery import string_to_date_range
 from .gql_types import SwipeDataType
@@ -264,7 +265,7 @@ def export_data(file_path):
     try:
         df = pd.read_csv(file_path)
         data = {}
-        today = date.today()
+        today = get_today()
         session_type = sort_session_type(today, breaks)
         for location in df["location"].unique():
             eatery_name = LOCATION_NAMES[location]["name"]


### PR DESCRIPTION
## Overview

Previously, we used `date.today()` to get the current date. However, this uses the local timezone and our servers use UTC time which is 5 hours ahead. This sometimes causes us to mistakenly think that the current date is actually one day ahead.

## Changes Made

Added function to get the current date in Eastern timezone. I added this to `constants.py` since there is no other file for helper functions.
