### PR TITLE
Support new BRB accounts

### DIFF
--- a/src/schema.py
+++ b/src/schema.py
@@ -90,7 +90,7 @@ class Query(ObjectType):
                 account_info["city_bucks"] = str("{0:.2f}".format(round(acct["balance"], 2)))
             elif acct["accountDisplayName"] == ACCOUNT_NAMES["laundry"]:
                 account_info["laundry"] = str("{0:.2f}".format(round(acct["balance"], 2)))
-            elif ACCOUNT_NAMES["brbs"] == acct["accountDisplayName"]:
+            elif ACCOUNT_NAMES["brbs"] in acct["accountDisplayName"]:
                 account_info["brbs"] = str("{0:.2f}".format(round(acct["balance"], 2)))
             elif any(meal_swipe_name in acct["accountDisplayName"] for meal_swipe_name in SWIPE_PLANS):
                 # Since swipes will always be >= 0, we set our swipes to the lowest value from GET


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->

A really small fix to add BRB support for Spring semester.

## Overview

<!-- Summarize your changes here. -->
Since the `"accountName"` field changed the BRB label from `"BRB Big Red Bucks"` to `"BRB Big Red Bucks Spring"` and we used an explicit equals, new BRB values were not being recognized. This fix should ideally also work in the Fall depending on how Get chooses to rename the BRB accounts.
