### PR TITLE
Fix cronjob to run in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,6 @@ EXPOSE 5000
 
 RUN touch /var/log/cron.log
 
-CMD sh start_server.sh 
+RUN crontab update_db.txt
+
+CMD cron && sh start_server.sh

--- a/start_server.sh
+++ b/start_server.sh
@@ -1,2 +1,1 @@
-crontab update_db.txt
 gunicorn -c gunicorn.py app:app


### PR DESCRIPTION
## Overview
There's some extra steps required to run a cronjob within a Docker container.

## Changes Made
Edited Dockerfile to actually run cronjob when the container starts and also added logging so we can verify

## Test Coverage
Tested by running locally


