### PR TITLE
Remove cron job for ctown

### DIFF
--- a/update_db.txt
+++ b/update_db.txt
@@ -1,2 +1,1 @@
 0 9,15,21 * * * cd /usr/src/app; /usr/local/bin/python update_campus.py >> /var/log/cron.log 2>&1
-0 5 * * 0 cd /usr/src/app; /usr/local/bin/python update_ctown.py >> /var/log/cron.log 2>&1


### PR DESCRIPTION
## Overview
Currently, ctown tries to update every week but cron doesn't have access to the required env vars it needs due to some weird stuff between cron and Docker. It's not necessary to update ctown eateries once a week since they rarely change and will update upon startup.

## Changes Made
- Remove ctown update job


