### PR TITLE
Fix date formatting for terrace

### DIFF
--- a/static_sources/externalEateries.json
+++ b/static_sources/externalEateries.json
@@ -19,7 +19,29 @@
             },
             "operatingHours": [
                 {
-                    "weekday": "sunday-saturday",
+                    "weekday": "monday-friday",
+                    "events": [
+                        {
+                            "descr": "General",
+                            "start": "11:00am",
+                            "end": "6:30pm",
+                            "menu": []
+                        }
+                    ]
+                },
+                {
+                    "weekday": "saturday",
+                    "events": [
+                        {
+                            "descr": "General",
+                            "start": "11:00am",
+                            "end": "6:30pm",
+                            "menu": []
+                        }
+                    ]
+                },
+                {
+                    "weekday": "sunday",
                     "events": [
                         {
                             "descr": "General",


### PR DESCRIPTION
The backend might not be able to parse sunday-saturday, moved the formatting to be monday-friday, saturday, sunday which has worked before