### PR TITLE
Updated version of Graphene and Werkzeug

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ Click==7.0
 file-read-backwards==2.0.0
 Flask==1.0.2
 Flask-GraphQL==2.0.0
-graphene==2.1.3
+graphene==2.1.5
 graphql-core==2.1
 graphql-relay==0.4.5
 graphql-server-core==1.1.1
@@ -30,5 +30,5 @@ six==1.11.0
 SQLAlchemy==1.3.10
 typing==3.6.6
 urllib3==1.24.2
-Werkzeug==0.15.3
+Werkzeug==0.15.5
 yelpapi==2.3.0


### PR DESCRIPTION
## Overview

Updated `Graphene` and `Werkzeug` dependency versions


## Changes Made

Updated `Graphene` from `2.1.3` to `2.1.5` to work with `aniso8601 v>4`
Updated `Werkzeug` from `0.15.3` to `0.15.5` to fix bug where `app = Flask(__name__)` would crash the program
