### PR TITLE
Add 'Mobile Order Only' Exception to Jansen's

### DIFF
--- a/static_sources/exceptions.json
+++ b/static_sources/exceptions.json
@@ -2,6 +2,9 @@
   "Bear-Necessities": [
     "Mobile Order Only"
   ],
+  "Jansens-Dining": [
+    "Mobile Order Only"
+  ],
   "Macs": [
     "Cash Only After 3PM"
   ]


### PR DESCRIPTION
## Overview
JSON edit of `exceptions.json` to add `Mobile Order Only` to Jansen's.