### PR TITLE
Fix Static Operating Hour Parsing Bug

### DIFF
--- a/src/db.py
+++ b/src/db.py
@@ -136,8 +136,12 @@ def start_update(refresh_campus=False, recalculate_swipe=False, refresh_colleget
         print("[{}] Updating static eatery hours and menus".format(datetime.now()))
         for eatery in static_eateries:
             if eatery.slug in STATIC_EATERY_SLUGS:
+                print("Updating Hours for: {}".format(eatery.slug))
                 hours_and_menus = parse_static_op_hours(static_json, eatery)
                 eatery_hours = (x[0] for x in hours_and_menus)
+                # if eatery.slug == "Terrace":
+                #     print("H&M:", hours_and_menus)
+                #     print("EH:", eatery_hours)
                 Session.add_all(eatery_hours)
                 Session.commit()
 

--- a/src/db.py
+++ b/src/db.py
@@ -139,9 +139,6 @@ def start_update(refresh_campus=False, recalculate_swipe=False, refresh_colleget
                 print("Updating Hours for: {}".format(eatery.slug))
                 hours_and_menus = parse_static_op_hours(static_json, eatery)
                 eatery_hours = (x[0] for x in hours_and_menus)
-                # if eatery.slug == "Terrace":
-                #     print("H&M:", hours_and_menus)
-                #     print("EH:", eatery_hours)
                 Session.add_all(eatery_hours)
                 Session.commit()
 

--- a/src/db.py
+++ b/src/db.py
@@ -136,7 +136,6 @@ def start_update(refresh_campus=False, recalculate_swipe=False, refresh_colleget
         print("[{}] Updating static eatery hours and menus".format(datetime.now()))
         for eatery in static_eateries:
             if eatery.slug in STATIC_EATERY_SLUGS:
-                print("Updating Hours for: {}".format(eatery.slug))
                 hours_and_menus = parse_static_op_hours(static_json, eatery)
                 eatery_hours = (x[0] for x in hours_and_menus)
                 Session.add_all(eatery_hours)

--- a/src/eatery_db/campus_eatery.py
+++ b/src/eatery_db/campus_eatery.py
@@ -223,13 +223,25 @@ def parse_static_op_hours(data_json, eatery_model):
                 if "-" in hours["weekday"]:
                     start, end = hours["weekday"].split("-")
                     start_index = WEEKDAYS[start]
-                    end_index = WEEKDAYS[end] + 1
-                    days = list(range(start_index, end_index))
+                    end_index = WEEKDAYS[end]
+                    days = []
+                    idx = start_index
+                    while idx != end_index:
+                        days.append(idx)
+                        idx += 1
+                        idx %= 7
+                    days.append(end_index)
                 else:
                     days = [WEEKDAYS[hours["weekday"]]]
                 for weekday in days:
                     if weekday not in weekdays:
                         weekdays[weekday] = hours["events"]
+
+            if eatery.get("slug") == "Terrace":
+                print("Days:", days)
+                print("S/E:", start, end)
+                print("SI/EI:", start_index, end_index)
+                print("Weekdays:", weekdays)
 
             new_operating_hours = []
             for i in range(NUM_DAYS_STORED_IN_DB):

--- a/src/eatery_db/campus_eatery.py
+++ b/src/eatery_db/campus_eatery.py
@@ -237,12 +237,6 @@ def parse_static_op_hours(data_json, eatery_model):
                     if weekday not in weekdays:
                         weekdays[weekday] = hours["events"]
 
-            if eatery.get("slug") == "Terrace":
-                print("Days:", days)
-                print("S/E:", start, end)
-                print("SI/EI:", start_index, end_index)
-                print("Weekdays:", weekdays)
-
             new_operating_hours = []
             for i in range(NUM_DAYS_STORED_IN_DB):
                 new_date = today + timedelta(days=i)

--- a/src/eatery_db/campus_eatery.py
+++ b/src/eatery_db/campus_eatery.py
@@ -228,8 +228,7 @@ def parse_static_op_hours(data_json, eatery_model):
                     idx = start_index
                     while idx != end_index:
                         days.append(idx)
-                        idx += 1
-                        idx %= 7
+                        idx = (idx + 1) % 7
                     days.append(end_index)
                 else:
                     days = [WEEKDAYS[hours["weekday"]]]


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->


## Overview
Static eateries had a problem parsing dates for their hour ranges; we were using the builtin python range method, which doesn't work if the start day is greater than the end day in our dictionary. 

## Changes Made
The fix was pretty simple, just replaced the range method with a loop and mod by 7 each time until we get to the end day. 


## Test Coverage
Manual testing on localhost had no issues.
