### PR TITLE
Update externalEateries.json

### DIFF
--- a/static_sources/attributes.json
+++ b/static_sources/attributes.json
@@ -66,5 +66,11 @@
   },
   "Terrace": {
     "is_get": true
+  },
+  "Zeus": {
+    "exceptions": [
+      "Mobile Order Only"
+    ],
+    "reserve_url": "https://cornell.revelup.online/store/1/category/30/subcategory/228"
   }
 }

--- a/static_sources/attributes.json
+++ b/static_sources/attributes.json
@@ -71,6 +71,6 @@
     "exceptions": [
       "Mobile Order Only"
     ],
-    "reserve_url": "https://cornell.revelup.online/store/1/category/30/subcategory/228"
+    "reserve_url": "https://cornell.revelup.online/store/1/"
   }
 }

--- a/static_sources/externalEateries.json
+++ b/static_sources/externalEateries.json
@@ -466,7 +466,7 @@
                 "descr": "Central Campus",
                 "descrshort": "Central"
             },
-            "location": "Gates HaTll",
+            "location": "Gates Hall",
             "eateryTypes": [
                 {
                     "descr": "Cafe",

--- a/static_sources/externalEateries.json
+++ b/static_sources/externalEateries.json
@@ -403,7 +403,19 @@
                     "descrshort": "cafe"
                 }
             ],
-            "operatingHours": [],
+            "operatingHours": [
+                {
+                    "weekday": "monday-friday",
+                    "events": [
+                        {
+                            "descr": "General",
+                            "start": "8:00am",
+                            "end": "2:00pm",
+                            "menu": []
+                        }
+                    ]
+                }
+            ],
             "datesClosed": [],
             "payMethods": [
                 {
@@ -454,7 +466,7 @@
                 "descr": "Central Campus",
                 "descrshort": "Central"
             },
-            "location": "Gates Hall",
+            "location": "Gates HaTll",
             "eateryTypes": [
                 {
                     "descr": "Cafe",


### PR DESCRIPTION
https://cornell.revelup.online/store/1/category/30/subcategory/228

Update temple of Zeus hours.

I also added a reserve url. Right now in app it says "Reserve on OpenTable", but it should take them to the webpage. It's a stopgap until we can distinguish between reserving on opentable and otherwise