### PR TITLE
Fix 104 West! OpenTable URL

### DIFF
--- a/static_sources/attributes.json
+++ b/static_sources/attributes.json
@@ -1,6 +1,6 @@
 {
   "104-West": {
-    "reserve_url": "https://www.opentable.com/restaurant/profile/1080703"
+    "reserve_url": "https://www.opentable.com/restaurant/profile/1081261"
   },
   "Bear-Necessities": {
     "exceptions": [


### PR DESCRIPTION

## Overview
104 West! url somehow directed to a Trillium passover menu, so that's been fixed.
