### PR TITLE
Fix Expanded Menus Associated with all Eateries

### DIFF
--- a/src/eatery_db/common_eatery.py
+++ b/src/eatery_db/common_eatery.py
@@ -73,12 +73,12 @@ def parse_expanded_menu(menus, eatery_model):
     items = []
 
     for menu in menus["eateries"]:
-        for station in menu["stations"]:
-            expanded_menu = ExpandedMenuStation(
-                campus_eatery_id=eatery_model.id,
-                station_category=station["station"],
-            )
-            items.append((expanded_menu, station["diningItems"]))
+        if menu["slug"] == eatery_model.slug:
+            for station in menu["stations"]:
+                expanded_menu = ExpandedMenuStation(
+                    campus_eatery_id=eatery_model.id, station_category=station["station"]
+                )
+                items.append((expanded_menu, station["diningItems"]))
     return items
 
 


### PR DESCRIPTION
## Overview
Expanded Menus were all assigned to every eatery; now they act as intended with their respective eateries.
