### PR TITLE
Update externalEateries.json

### DIFF
--- a/static_sources/externalEateries.json
+++ b/static_sources/externalEateries.json
@@ -36,7 +36,12 @@
                     ]
                 }
             ],
-            "datesClosed": [],
+            "datesClosed": [
+                "5/31/21",
+                "6/1/21",
+                "6/2/21",
+                "6/3/21"
+            ],
             "payMethods": [
                 {
                     "descr": "Cash",


### PR DESCRIPTION
From Jana: 

> We will be open as normal through this Sunday, May 30, 11:00am – 6:30pm.
> We will be closed May 31 – June 3.
> When we reopen on June 4, it will be with our summer hours, 10:00am – 2:30pm, Monday – Friday.
> Those hours will remain constant for the summer, aside from the Cornell  University Holidays.

I will submit another PR on May 31 to adjust for summer hours
