### PR TITLE
Update externalEateries.json

### DIFF
--- a/static_sources/externalEateries.json
+++ b/static_sources/externalEateries.json
@@ -30,7 +30,7 @@
                         {
                             "descr": "General",
                             "start": "10:00am",
-                            "end": "2:30pm",
+                            "end": "3:00pm",
                             "menu": []
                         }
                     ]
@@ -38,10 +38,6 @@
             ],
             "datesClosed": [
                 "9/6/21",
-                "10/9/21",
-                "10/10/21",
-                "10/11/21",
-                "10/12/21",
                 "11/24/21",
                 "11/25/21",
                 "11/26/21",
@@ -114,12 +110,23 @@
             ],
             "operatingHours": [
                 {
-                    "weekday": "monday-friday",
+                    "weekday": "tuesday-wednesday",
                     "events": [
                         {
                             "descr": "General",
                             "start": "7:30am",
                             "end": "5:30pm",
+                            "menu": []
+                        }
+                    ]
+                },
+                {
+                    "weekday": "thursday-friday",
+                    "events": [
+                        {
+                            "descr": "General",
+                            "start": "7:30am",
+                            "end": "7:30pm",
                             "menu": []
                         }
                     ]


### PR DESCRIPTION
Need one more pull request next week to update Mac's

> Terrace:
> Beginning Monday, August 23, 10:00am – 3:00pm, Monday – Friday.  Closed for Labor Day.
> No GET beginning August 23.
> 
> Mac’s Café:
> GET orders only for the semester.
> August 24 and 25:  7:30am – 5:30pm
> Beginning August 26, 7:30am – 7:30pm, Monday – Friday, when class is in session.
> 
> Terrace will be open through Fall Break, but Mac’s closed – correct.
> Terrace will be open November 24th until 1:30pm only.