### PR TITLE
Update Mac's hours for FA22 in externalEateries.json

### DIFF
--- a/static_sources/externalEateries.json
+++ b/static_sources/externalEateries.json
@@ -110,7 +110,18 @@
             ],
             "operatingHours": [
                 {
-                    "weekday": "monday-friday",
+                    "weekday": "monday-thursday",
+                    "events": [
+                        {
+                            "descr": "General",
+                            "start": "8:00am",
+                            "end": "7:30pm",
+                            "menu": []
+                        }
+                    ]
+                },
+                {
+                    "weekday": "friday",
                     "events": [
                         {
                             "descr": "General",


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->


## Overview

<!-- Summarize your changes here. -->

Updating the JSON to satisfy this request.

The hours for the semester are:
Terrace:
Monday – Friday, 10:00am – 3:00pm

Mac’s: Opens August 18
August 18 and 19, 8:00am – 5:30pm
After that:  Monday – Thursday, 8:00am – 7:30pm, Friday, 8:00am – 5:30pm

## Changes Made

<!-- Include details of what your changes actually are and how it is intended to work. -->
Terrace remained the same as hours are the same.
Too late to make the temporary change for Mac's but the 7:30pm for M-R and 5:30pm for F has been changed.
